### PR TITLE
update parser to handle Specta 0.2.1

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -71,14 +71,14 @@ module XCPretty
 
     # @regex Captured groups
     #
-    EXECUTED_MATCHER = /^Executed/
+    EXECUTED_MATCHER = /^\s*Executed/
 
     # @regex Captured groups
     # $1 = file
     # $2 = test_suite
     # $3 = test_case
     # $4 = reason
-    FAILING_TEST_MATCHER = /^(.+:\d+):\serror:\s[\+\-]\[(.*)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)/
+    FAILING_TEST_MATCHER = /^\s*(.+:\d+):\serror:\s[\+\-]\[(.*)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)/
 
     # @regex Captured groups
     # $1 = whole error.
@@ -111,7 +111,7 @@ module XCPretty
     # $1 = suite
     # $2 = test_case
     # $3 = time
-    PASSING_TEST_MATCHER = /^Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)/
+    PASSING_TEST_MATCHER = /^\s*Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)/
 
     # @regex Captured groups
     # $1 = suite
@@ -148,16 +148,16 @@ module XCPretty
     # @regex Captured groups
     # $1 = suite
     # $2 = time
-    TESTS_RUN_COMPLETION_MATCHER = /Test Suite '(?:.*\/)?(.*[ox]ctest.*)' finished at (.*)/
+    TESTS_RUN_COMPLETION_MATCHER = /^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' finished at (.*)/
 
     # @regex Captured groups
     # $1 = suite
     # $2 = time
-    TESTS_RUN_START_MATCHER = /Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)/
+    TESTS_RUN_START_MATCHER = /^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)/
 
     # @regex Captured groups
     # $1 test suite name
-    TEST_SUITE_START_MATCHER = /Test Suite '(.*)' started at/
+    TEST_SUITE_START_MATCHER = /^\s*Test Suite '(.*)' started at/
 
     # @regex Captured groups
     # $1 file_name

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -4,16 +4,20 @@ KIWI = 'kiwi'
 OCUNIT = 'ocunit'
 SAMPLE_OCUNIT_TEST_RUN_BEGINNING = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' started at 2013-12-10 07:04:33 +0000"
 SAMPLE_KIWI_TEST_RUN_BEGINNING = "Test Suite 'ObjectiveRecordTests.xctest' started at 2013-12-10 06:15:39 +0000"
+SAMPLE_SPECTA_TEST_RUN_BEGINNING = "    Test Suite 'KIFTests.xctest' started at 2014-02-28 15:43:42 +0000"
 SAMPLE_OCUNIT_TEST_RUN_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-10 07:03:03 +0000."
 SAMPLE_KIWI_TEST_RUN_COMPLETION = "Test Suite 'ObjectiveRecordTests.xctest' finished at 2013-12-10 06:15:42 +0000."
+SAMPLE_SPECTA_TEST_RUN_COMPLETION = "     Test Suite 'KIFTests.xctest' finished at 2014-02-28 15:44:32 +0000."
 
 SAMPLE_OCUNIT_SUITE_BEGINNING = "Test Suite 'RACKVOWrapperSpec' started at 2013-12-10 21:06:10 +0000"
+SAMPLE_SPECTA_SUITE_BEGINNING = "   Test Suite 'All tests' started at 2014-02-28 19:07:41 +0000"
 SAMPLE_KIWI_SUITE_COMPLETION = "Test Suite 'All tests' finished at 2013-12-08 04:26:49 +0000."
 SAMPLE_OCUNIT_SUITE_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-08 22:09:37 +0000."
 SAMPLE_XCTEST_SUITE_COMPLETION = "Test Suite 'ObjectiveSugarTests.xctest' finished at 2013-12-09 04:42:13 +0000."
 
 SAMPLE_KIWI_FAILURE = "/Users/musalj/code/OSS/ObjectiveSugar/Example/ObjectiveSugarTests/NSNumberTests.m:49: error: -[NumberAdditions Iterators_TimesIteratesTheExactNumberOfTimes] : 'Iterators, times： iterates the exact number of times' [FAILED], expected subject to equal 4, got 5"
-SAMPLE_SPECTA_FAILURE = "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458: error: -[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES] : expected: 1, got: 0"
+SAMPLE_OLD_SPECTA_FAILURE = "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458: error: -[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES] : expected: 1, got: 0"
+SAMPLE_SPECTA_FAILURE = "         Test Case '-[SKWelcomeViewControllerSpecSpec SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen]' started. \n/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11: error: -[SKWelcomeViewControllerSpecSpec SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen] : The step timed out after 2.00 seconds: Failed to find accessibility element with the label \"The asimplest way to make smarter business decisions\""
 
 SAMPLE_BUILD = "=== BUILD TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ==="
 SAMPLE_CLEAN = "=== CLEAN TARGET Pods-ObjectiveSugar OF PROJECT Pods WITH CONFIGURATION Debug ==="
@@ -23,7 +27,9 @@ Clean.Remove clean /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSu
     builtin-rm -rf /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugarTests.build
 )
 SAMPLE_EXECUTED_TESTS = "Executed 4 tests, with 0 failures (0 unexpected) in 0.003 (0.004) seconds"
+SAMPLE_SPECTA_EXECUTED_TESTS = "       Executed 4 tests, with 0 failures (0 unexpected) in 10.192 (10.193) seconds"
 SAMPLE_OCUNIT_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.001 seconds)."
+SAMPLE_SPECTA_TEST = "         Test Case '-[SKWelcomeActivationViewControllerSpecSpec SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code]' passed (0.725 seconds)."
 SAMPLE_SLOWISH_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.026 seconds)."
 SAMPLE_SLOW_TEST = "Test Case '-[RACCommandSpec enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES]' passed (0.101 seconds)."
 SAMPLE_KIWI_TEST = "Test Case '-[MappingsTests Mappings_SupportsCreatingAParentObjectUsingJustIDFromTheServer]' passed (0.004 seconds)."

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -115,20 +115,34 @@ module XCPretty
       @parser.parse(SAMPLE_LIBTOOL)
     end
 
-    it "parses failing tests" do
-      @formatter.should receive(:format_failing_test).with("RACCommandSpec",
-                                                           "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES",
-                                                           "expected: 1, got: 0",
-                                                           #"expect([command.enabled first]).to.equal(@YES);", # outside of PR scope
-                                                           "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458")
+    it "parses specta failing tests" do
+      @formatter.should receive(:format_failing_test).with("SKWelcomeViewControllerSpecSpec",
+                                                           "SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen",
+                                                           "The step timed out after 2.00 seconds: Failed to find accessibility element with the label \"The asimplest way to make smarter business decisions\"",
+                                                           "/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11")
       @parser.parse(SAMPLE_SPECTA_FAILURE)
     end
 
-    it "parses passing tests" do
+    it "parses old specta failing tests" do
+      @formatter.should receive(:format_failing_test).with("RACCommandSpec",
+                                                           "enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES",
+                                                           "expected: 1, got: 0",
+                                                           "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaFramework/ReactiveCocoaTests/RACCommandSpec.m:458")
+      @parser.parse(SAMPLE_OLD_SPECTA_FAILURE)
+    end
+
+    it "parses passing ocunit tests" do
       @formatter.should receive(:format_passing_test).with('RACCommandSpec',
                                                            'enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES',
                                                            '0.001')
       @parser.parse(SAMPLE_OCUNIT_TEST)
+    end
+
+    it "parses passing specta tests" do
+      @formatter.should receive(:format_passing_test).with('SKWelcomeActivationViewControllerSpecSpec',
+                                                           'SKWelcomeActivationViewController_When_a_user_enters_their_details_lets_them_enter_a_valid_manager_code',
+                                                           '0.725')
+      @parser.parse(SAMPLE_SPECTA_TEST)
     end
 
     it "parses pending tests" do
@@ -179,19 +193,34 @@ module XCPretty
       end
     end
 
-    it "parses test run finished" do
+    it "parses ocunit test run finished" do
       @formatter.should receive(:format_test_run_finished).with('ReactiveCocoaTests.octest(Tests)', '2013-12-10 07:03:03 +0000.')
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_COMPLETION)
     end
 
-    it "parses test run started" do
+    it "parses specta test run finished" do
+      @formatter.should receive(:format_test_run_finished).with('KIFTests.xctest', '2014-02-28 15:44:32 +0000.')
+      @parser.parse(SAMPLE_SPECTA_TEST_RUN_COMPLETION)
+    end
+
+    it "parses ocunit test run started" do
       @formatter.should receive(:format_test_run_started).with('ReactiveCocoaTests.octest(Tests)')
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_BEGINNING)
     end
 
-    it "parses test suite started" do
+    it "parses specta test run started" do
+      @formatter.should receive(:format_test_run_started).with('KIFTests.xctest')
+      @parser.parse(SAMPLE_SPECTA_TEST_RUN_BEGINNING)
+    end
+
+    it "parses ocunit test suite started" do
       @formatter.should receive(:format_test_suite_started).with('RACKVOWrapperSpec')
       @parser.parse(SAMPLE_OCUNIT_SUITE_BEGINNING)
+    end
+
+    it "parses specta test suite started" do
+      @formatter.should receive(:format_test_suite_started).with('All tests')
+      @parser.parse(SAMPLE_SPECTA_SUITE_BEGINNING)
     end
 
     context "errors" do
@@ -323,10 +352,16 @@ module XCPretty
         @parser.parse(SAMPLE_EXECUTED_TESTS).should == ""
       end
 
-      it "knows when the test suite is done for OCunit / Specta" do
+      it "knows when the test suite is done for OCunit" do
         given_tests_are_done
         @formatter.should receive(:format_test_summary)
         @parser.parse(SAMPLE_EXECUTED_TESTS)
+      end
+
+      it "knows when the test suite is done for Specta" do
+        given_tests_are_done
+        @formatter.should receive(:format_test_summary)
+        @parser.parse(SAMPLE_SPECTA_EXECUTED_TESTS)
       end
 
       it "doesn't print executed message twice for Kiwi tests" do


### PR DESCRIPTION
Specta 0.2.1 introduced indentation in the test output.

This commit updates the regexes for:
- FAILING_TEST_MATCHER
- TESTS_RUN_COMPLETION_MATCHER
- TESTS_RUN_START_MATCHER
- TEST_SUITE_START_MATCHER
- EXECUTED_MATCHER
- SAMPLE_SPECTA_TEST

To allow for optional whitespace at the start of the lines
