### PR TITLE
close report file after writing

### DIFF
--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -62,7 +62,10 @@ module XCPretty
       FileUtils.mkdir_p(File.dirname(@filepath))
       formatter = REXML::Formatters::Pretty.new(2)
       formatter.compact = true
-      formatter.write(@document, File.open(@filepath, 'w+'))
+      output_file = File.open(@filepath, 'w+')
+      result = formatter.write(@document, output_file)
+      output_file.close
+      result
     end
 
     def suite(classname)


### PR DESCRIPTION
If the file is not closed (which File.open doesn't do automatically if it not passed a block) and the xcpretty ruby library is used from within another process (not the command line, where the file is closed after the xcpretty process exits), then you have an open file with pending writes that cannot be used. 
