### PR TITLE
Changes {classname} to {target.classname} to show targets in jenkins

### DIFF
--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -86,7 +86,7 @@ module XCPretty
 
       set_test_counters
       @last_suite = @document.root.add_element('testsuite')
-      @last_suite.attributes['name'] = "#{@target}.#{classname}"
+      @last_suite.attributes['name'] = classname
       @last_suite
     end
 


### PR DESCRIPTION
I changed classname to target.classname as shown below. This will show the tests by target groups in Jenkins in the Test Results. In Java this is done automatically based on packages.

<testsuite name='TestTarget.TestClass' tests='1' failures='0'>
    <testcase classname='TestTarget.TestClass' name='testFunction' time='0.000'/>
  </testsuite>
