### PR TITLE
Fixes #101 - Handle suite completion text changes in Xcode 6

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -114,7 +114,7 @@ module XCPretty
     # @regex Captured groups
     # $1 = suite
     # $2 = time
-    TESTS_RUN_COMPLETION_MATCHER = /^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' finished at (.*)/
+    TESTS_RUN_COMPLETION_MATCHER = /^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' (finished|passed|failed) at (.*)/
 
     # @regex Captured groups
     # $1 = suite
@@ -267,7 +267,7 @@ module XCPretty
       when PBXCP_MATCHER
         formatter.format_pbxcp($1)
       when TESTS_RUN_COMPLETION_MATCHER
-        formatter.format_test_run_finished($1, $2)
+        formatter.format_test_run_finished($1, $3)
       when TESTS_RUN_START_MATCHER
         formatter.format_test_run_started($1)
       when TEST_SUITE_START_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -6,6 +6,8 @@ SAMPLE_OCUNIT_TEST_RUN_BEGINNING = "Test Suite '/Users/musalj/Library/Developer/
 SAMPLE_KIWI_TEST_RUN_BEGINNING = "Test Suite 'ObjectiveRecordTests.xctest' started at 2013-12-10 06:15:39 +0000"
 SAMPLE_SPECTA_TEST_RUN_BEGINNING = "    Test Suite 'KIFTests.xctest' started at 2014-02-28 15:43:42 +0000"
 SAMPLE_OCUNIT_TEST_RUN_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-10 07:03:03 +0000."
+SAMPLE_OCUNIT_FAILED_TEST_RUN_COMPLETION = "Test Suite '/Users/dm/someplace/Macadamia.octest' failed at 2014-09-24 23:09:20 +0000."
+SAMPLE_OCUNIT_PASSED_TEST_RUN_COMPLETION = "Test Suite 'Hazelnuts.xctest' passed at 2014-09-24 23:09:20 +0000."
 SAMPLE_KIWI_TEST_RUN_COMPLETION = "Test Suite 'ObjectiveRecordTests.xctest' finished at 2013-12-10 06:15:42 +0000."
 SAMPLE_SPECTA_TEST_RUN_COMPLETION = "     Test Suite 'KIFTests.xctest' finished at 2014-02-28 15:44:32 +0000."
 

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -211,11 +211,19 @@ module XCPretty
       end
     end
 
-
-
     it "parses ocunit test run finished" do
       @formatter.should receive(:format_test_run_finished).with('ReactiveCocoaTests.octest(Tests)', '2013-12-10 07:03:03 +0000.')
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_COMPLETION)
+    end
+
+    it "parses ocunit test run passed" do
+      @formatter.should receive(:format_test_run_finished).with('Hazelnuts.xctest', '2014-09-24 23:09:20 +0000.')
+      @parser.parse(SAMPLE_OCUNIT_PASSED_TEST_RUN_COMPLETION)
+    end
+
+    it "parses ocunit test run failed" do
+      @formatter.should receive(:format_test_run_finished).with('Macadamia.octest', '2014-09-24 23:09:20 +0000.')
+      @parser.parse(SAMPLE_OCUNIT_FAILED_TEST_RUN_COMPLETION)
     end
 
     it "parses specta test run finished" do


### PR DESCRIPTION
- Test suite completion text now says ‘passed’ or ‘failed’ instead of
  only ‘finished’.
- Left existing support for ‘finished’ in place for users of old
  versions of Xcode
