### PR TITLE
Use blacklisting instead of whitelisting for printing test output

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -59,6 +59,8 @@ module XCPretty
     #       the same for warnings
     def format_compile_warning(file_name, file_path, reason,
                                line, cursor);                  EMPTY; end
+    # OTHER OUTPUT
+    def format_other_output(text);                             EMPTY; end
   end
 
   class Formatter

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -23,6 +23,7 @@ module XCPretty
     def format_copy_plist_file(source, target);                EMPTY; end
     def format_copy_strings_file(file_name);                   EMPTY; end
     def format_cpresource(file);                               EMPTY; end
+    def format_empty_line(text);                               EMPTY; end
     def format_generate_dsym(dsym);                            EMPTY; end
     def format_linking(file, build_variant, arch);             EMPTY; end
     def format_libtool(library);                               EMPTY; end

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -75,6 +75,10 @@ module XCPretty
       INDENT + format_test("#{test_case}, #{reason}", :fail)
     end
 
+    def format_other_output(text)
+      text
+    end
+
     def format_passing_test(suite, test_case, time)
       INDENT + format_test("#{test_case} (#{colored_time(time)} seconds)", :pass)
     end

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -79,6 +79,9 @@ module XCPretty
     CPRESOURCE_MATCHER = /^CpResource\s(.*)\s\//
 
     # @regex Captured groups
+    # $1 whitespace
+    EMPTY_LINE_MATCHER = /^([\n\s]+)$/
+
     #
     EXECUTED_MATCHER = /^\s*Executed/
 
@@ -298,6 +301,8 @@ module XCPretty
         formatter.format_copy_plist_file($1, $2)
       when CPRESOURCE_MATCHER
         formatter.format_cpresource($1)
+      when EMPTY_LINE_MATCHER
+        formatter.format_empty_line($1)
       when EXECUTED_MATCHER
         format_summary_if_needed(text)
       when FAILING_TEST_MATCHER

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -27,7 +27,8 @@ module XCPretty
     # @regex Captured groups
     # $1 command path
     # $2 arguments
-    SHELL_COMMAND_MATCHER = /^\s{4}(cd|setenv|(?:[\w\/:\\\s\-.]+?\/)?[\w\-]+)\s(.*)$/
+    SHELL_COMMAND_MATCHER =
+     /^(?:\s{4})?(cd|setenv|mkdir|(?:[\w\/:\\\s\-.]+?bin\/)[\w\-]+)\s(.*)$/
 
     # @regex Nothing returned here for now
     CLEAN_REMOVE_MATCHER = /^Clean.Remove/

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -353,7 +353,7 @@ module XCPretty
       when GENERIC_WARNING_MATCHER
         formatter.format_warning($1)
       else
-        ""
+        formatter.format_other_output(text)
       end
     end
 

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -150,5 +150,8 @@ module XCPretty
         "> Validating unbelievable.tiff"
       end
 
+      it 'formats unknown output types' do
+        @formatter.format_other_output('some text?').should == 'some text?'
+      end
     end
 end

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -153,5 +153,9 @@ module XCPretty
       it 'formats unknown output types' do
         @formatter.format_other_output('some text?').should == 'some text?'
       end
+
+      it 'formats whitespace-only lines' do
+        @formatter.format_empty_line("\n \t\t").should == ''
+      end
     end
 end

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -268,6 +268,12 @@ module XCPretty
       end
     end
 
+    it 'parses unknown text patterns' do
+      text = 'This is just some text?'
+      @formatter.should receive(:format_other_output).with(text)
+      @parser.parse(text)
+    end
+
     it "parses duplicate symbols" do
       @formatter.should receive(:format_duplicate_symbols).with(
         "duplicate symbol _OBJC_IVAR_$ClassName._ivarName in",

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -274,6 +274,11 @@ module XCPretty
       @parser.parse(text)
     end
 
+    it 'parses whitespace-only lines' do
+      @formatter.should receive(:format_empty_line).with("\t\t  ")
+      @parser.parse("\t\t  ")
+    end
+
     it "parses duplicate symbols" do
       @formatter.should receive(:format_duplicate_symbols).with(
         "duplicate symbol _OBJC_IVAR_$ClassName._ivarName in",

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -148,6 +148,12 @@ module XCPretty
       @parser.parse(SAMPLE_LIBTOOL)
     end
 
+    it 'parses mkdir invocations' do
+      @formatter.should receive(:format_shell_command).with(
+        '/bin/mkdir', '-p build/some stuff/here')
+      @parser.parse('/bin/mkdir -p build/some stuff/here')
+    end
+
     it "parses specta failing tests" do
       @formatter.should receive(:format_failing_test).with("SKWelcomeViewControllerSpecSpec",
                                                            "SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen",
@@ -230,10 +236,15 @@ module XCPretty
       @parser.parse('    cd /some/place/out\ there')
     end
 
-    it 'parses any indented command' do
+    it 'parses any indented command in a bin dir' do
       @formatter.should receive(:format_shell_command).with(
         '/bin/rm', '-rf /bin /usr /Users')
       @parser.parse('    /bin/rm -rf /bin /usr /Users')
+    end
+
+    it 'does not filter an indented path not in a bin dir' do
+      @formatter.should_not receive(:format_shell_command)
+      @parser.parse('    /some/path/to/a/file -flags arg1 arg2')
     end
 
     it "parses Touch" do


### PR DESCRIPTION
Added a handler for text not matching any pattern, plus handling for blank lines. The simple formatter outputs unmatched text by default.

Unhandled items include:
- generic output messages. these have no standard format but examples include:
  - `Create product structure`
  - `Build settings from command line:`
  - `… done`
- output from third-party test frameworks:
  - `Test Case '-[ABCSomething test_something_is_nil]' started.`
  - `Test Suite 'SASalesHistoryTableObjectTests' finished at 2013-12-30 22:08:53 +0000.`
- `NSLog` statements, which have a first line matching `/^(\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:[\d.]+)\s(.*\[[0-9a-f:]+\])\s(.*)/` but may continue for several lines in any format
