### PR TITLE
Make TOUCH_MATCHER match the whole file name

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -151,7 +151,7 @@ module XCPretty
     # @regex Captured groups
     # $1 file_path
     # $2 file_name
-    TOUCH_MATCHER = /^Touch\s(.*\/([\w+\.]+))/
+    TOUCH_MATCHER = /^Touch\s(.*\/(.*))/
 
     module Errors
       # @regex Captured groups


### PR DESCRIPTION
This pull request fixes the `TOUCH_MATCHER` matching incomplete file names.

Consider the following `xcodebuild` output:

```none
Touch /Path/To/Build/Products/Test-iphonesimulator/Unit\ Tests.xctest
```

Expected output from `xcpretty`:

```none
▸ Touching Unit\ Tests.xctest
```

Actual output:

```none
▸ Touching Unit
```