### PR TITLE
Formatting of 'info' messages printed by xcodebuild

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -54,6 +54,8 @@ module XCPretty
     def format_duplicate_symbols(message, file_paths);        EMPTY; end
     def format_warning(message);                            message; end
 
+    def format_info(message);                                 EMPTY; end
+
     # TODO: see how we can unify format_error and format_compile_error,
     #       the same for warnings
     def format_compile_warning(file_name, file_path, reason,

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -229,6 +229,19 @@ module XCPretty
       # $1 = reference
       SYMBOL_REFERENCED_FROM_MATCHER = /\s+"(.*)", referenced from:$/
     end
+
+    module Informative
+      # @regex Captured groups
+      # $1 = whole info
+      # $2 = message
+      # $3 = plugin name
+      PLUGIN_LOADING_MATCHER = /^.+(\[MT\] PluginLoading: (.*?(?:([\w]+)\.xcplugin).*))$/
+
+      # @regex Captured groups
+      # $1 = whole info
+      # $2 = message
+      IPHONE_SIMULATOR_MATCHER = /^.+(\[MT\] iPhoneSimulator: (.*))$/
+    end
   end
 
   class Parser
@@ -236,6 +249,7 @@ module XCPretty
     include Matchers
     include Matchers::Errors
     include Matchers::Warnings
+    include Matchers::Informative
 
     attr_reader :formatter
 
@@ -338,6 +352,10 @@ module XCPretty
         formatter.format_shell_command($1, $2)
       when GENERIC_WARNING_MATCHER
         formatter.format_warning($1)
+      when PLUGIN_LOADING_MATCHER
+        formatter.format_info($1)
+      when IPHONE_SIMULATOR_MATCHER
+        formatter.format_info($1)
       else
         ""
       end

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -575,3 +575,17 @@ SAMPLE_FORMAT_WARNING = %Q(
                          %d
 1 warning generated.
 )
+
+
+################################################################################
+# INFORMATIVE
+################################################################################
+
+SAMPLE_PLUGIN_INFO = %Q(2015-04-23 10:20:09.018 xcodebuild[77828:9774464] [MT] PluginLoading: Required plug-in compatibility UUID 9F75337B-21B4-4ADC-B558-F9CADF7073A7 for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/AllMissingXcodeFeatures.xcplugin' not present in DVTPlugInCompatibilityUUIDs)
+
+SAMPLE_PLUGIN_INFO_TRIMMED = %Q([MT] PluginLoading: Required plug-in compatibility UUID 9F75337B-21B4-4ADC-B558-F9CADF7073A7 for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/AllMissingXcodeFeatures.xcplugin' not present in DVTPlugInCompatibilityUUIDs)
+
+SAMPLE_IPHONE_SIMULATOR_INFO = %Q(2015-04-23 10:20:09.161 xcodebuild[77828:9774464] [MT] iPhoneSimulator: SimVerifier returned: Error Domain=NSPOSIXErrorDomain Code=53 "Simulator verification failed." UserInfo=0x7f81829c2240 {NSLocalizedFailureReason=A connection to the simulator verification service could not be established., NSLocalizedRecoverySuggestion=Ensure that Xcode.app is installed on a volume with ownership enabled., NSLocalizedDescription=Simulator verification failed.})
+
+SAMPLE_IPHONE_SIMULATOR_INFO_TRIMMED = %Q([MT] iPhoneSimulator: SimVerifier returned: Error Domain=NSPOSIXErrorDomain Code=53 "Simulator verification failed." UserInfo=0x7f81829c2240 {NSLocalizedFailureReason=A connection to the simulator verification service could not be established., NSLocalizedRecoverySuggestion=Ensure that Xcode.app is installed on a volume with ownership enabled., NSLocalizedDescription=Simulator verification failed.})
+

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -494,5 +494,17 @@ module XCPretty
       end
     end
 
+    context "informative" do
+      it 'parses plugin loading info' do
+        @formatter.should receive(:format_info).with(SAMPLE_PLUGIN_INFO_TRIMMED)
+        @parser.parse(SAMPLE_PLUGIN_INFO)
+      end
+
+      it 'parses iphone simulator info' do
+        @formatter.should receive(:format_info).with(SAMPLE_IPHONE_SIMULATOR_INFO_TRIMMED)
+        @parser.parse(SAMPLE_IPHONE_SIMULATOR_INFO)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
eg: PluginLoading and iPhoneSimulator messages.

The default formatter suppresses messages like these, but they can be hooked into by subclasses like normal.

```
2015-04-23 10:20:09.018 xcodebuild[77828:9774464] [MT] PluginLoading: Required plug-in compatibility UUID 9F75337B-21B4-4ADC-B558-F9CADF7073A7 for plug-in at path '~/Library/Application Support/Developer/Shared/Xcode/Plug-ins/AllMissingXcodeFeatures.xcplugin' not present in DVTPlugInCompatibilityUUIDs
2015-04-23 10:20:09.161 xcodebuild[77828:9774464] [MT] iPhoneSimulator: SimVerifier returned: Error Domain=NSPOSIXErrorDomain Code=53 "Simulator verification failed." UserInfo=0x7f81829c2240 {NSLocalizedFailureReason=A connection to the simulator verification service could not be established., NSLocalizedRecoverySuggestion=Ensure that Xcode.app is installed on a volume with ownership enabled., NSLocalizedDescription=Simulator verification failed.
```


I'm strong in ruby so I expect to have some things to fix up, feedback welcome of course.

:heart_eyes: **xcpretty**