### PR TITLE
Use rouge for highlighting instead of Pygments

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,7 @@ RuboCop::RakeTask.new(:lint) do |task|
   task.fail_on_error = false
 end
 
-task :install_tools do
-  sh 'sudo pip install Pygments'
-end
-
 task :ci do
-  Rake::Task[:install_tools].invoke
   Rake::Task[:spec].invoke
   Rake::Task[:cucumber].invoke
   Rake::Task[:lint].invoke

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -48,7 +48,7 @@ module XCPretty
 
     def formatted_snippet(filepath)
       snippet = Snippet.from_filepath(filepath)
-      Syntax.highlight(snippet, "-f html -O style=colorful -O noclasses")
+      Syntax.highlight(snippet)
     end
 
 

--- a/lib/xcpretty/syntax.rb
+++ b/lib/xcpretty/syntax.rb
@@ -17,22 +17,31 @@ module XCPretty
         filename = snippet.file_path
       end
 
-      options = {
-        :filename => File.basename(filename),
-        :source => snippet.contents,
-      }
-      lexer = Rouge::Lexer.guesses(options).first
-
-      if !lexer && File.extname(filename) == '.m'
-        # Objective-C is hard to guess when you use BDD style frameworks like Kiwi and Specta
-        lexer = Rouge::Lexers::ObjectiveC
-      end
-
+      lexer = find_lexer(filename, snippet.contents)
       if lexer
         formatter = Rouge::Formatters::Terminal256.new
         formatter.format(lexer.lex(snippet.contents))
       else
         snippet.contents
+      end
+    end
+
+    # @param [String] filename The filename
+    # @param [String] contents The contents of the file
+    # @return [Rouge::Lexer]
+    def self.find_lexer(filename, contents)
+      case File.extname(filename)
+      when '.cpp', '.cc', '.c++', '.cxx', '.hpp', '.h++', '.hxx'
+        Rouge::Lexers::Cpp
+      when '.m', '.h' then Rouge::Lexers::ObjectiveC
+      when '.swift' then Rouge::Lexers::Swift
+      when '.ruby', '.rb' then Rouge::Lexers::Ruby
+      else
+        options = {
+          filename: File.basename(filename),
+          source: contents
+        }
+        Rouge::Lexer.guesses(options).first
       end
     end
   end

--- a/lib/xcpretty/syntax.rb
+++ b/lib/xcpretty/syntax.rb
@@ -1,7 +1,9 @@
 begin
   require 'rouge'
 rescue LoadError
+  # rubocop:disable Style/ConstantName
   Rouge = nil
+  # rubocop:enable Style/ConstantName
 end
 
 require 'xcpretty/snippet'

--- a/lib/xcpretty/syntax.rb
+++ b/lib/xcpretty/syntax.rb
@@ -1,9 +1,16 @@
-require 'rouge'
+begin
+  require 'rouge'
+rescue LoadError
+  Rouge = nil
+end
+
 require 'xcpretty/snippet'
 
 module XCPretty
   module Syntax
     def self.highlight(snippet)
+      return snippet.contents unless Rouge
+
       if snippet.file_path.include?(':')
         filename = snippet.file_path.rpartition(':').first
       else

--- a/spec/xcpretty/syntax_spec.rb
+++ b/spec/xcpretty/syntax_spec.rb
@@ -11,6 +11,30 @@ module XCPretty
       stripped_output.should == code
       stripped_output.should_not == output
     end
+
+    it 'uses Objective-C lexer for Objective-C' do
+      Syntax.find_lexer('test.m', '').should == Rouge::Lexers::ObjectiveC
+      Syntax.find_lexer('test.h', '').should == Rouge::Lexers::ObjectiveC
+    end
+
+    it 'uses Swift lexer for Swift' do
+      Syntax.find_lexer('test.swift', '').should == Rouge::Lexers::Swift
+    end
+
+    it 'uses Ruby lexer for Ruby' do
+      Syntax.find_lexer('test.rb', '').should == Rouge::Lexers::Ruby
+      Syntax.find_lexer('test.ruby', '').should == Rouge::Lexers::Ruby
+    end
+
+    it 'uses C++ lexer for C++' do
+      Syntax.find_lexer('test.cpp', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.cc', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.c++', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.cxx', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.hpp', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.h++', '').should == Rouge::Lexers::Cpp
+      Syntax.find_lexer('test.hxx', '').should == Rouge::Lexers::Cpp
+    end
   end
 end
 

--- a/spec/xcpretty/syntax_spec.rb
+++ b/spec/xcpretty/syntax_spec.rb
@@ -1,62 +1,15 @@
 require 'xcpretty/syntax'
 
 module XCPretty
-
   describe Syntax do
+    it 'syntax highlights given code' do
+      code = 'self.color = [UIColor redColor];'
+      snippet = Snippet.new(code, 'test.m')
+      output = Syntax.highlight(snippet)
 
-    let(:snippet) { Snippet.new('self.color = [UIColor redColor];', 'test.m') }
-    let(:code) { snippet.contents }
-
-    it "caches the pygments availability" do
-      Pygments.should_receive(:system).once.and_return(false)
-      4.times { Syntax.highlight(Snippet.new('meh')) }
-    end
-
-    context "pygments are installed" do
-
-      before(:each) do
-        Pygments.stub(:available?).and_return(true)
-      end
-
-      it 'supports highlighting with options' do
-        Pygments.should_receive(:pygmentize).with(code, 'objc', '-f html')
-        Syntax.highlight(snippet, '-f html')
-      end
-
-      it 'highlights objective-c code by filename' do
-        Pygments.should_receive(:pygmentize).with(code, 'objc', '')
-        Syntax.highlight(snippet)
-      end
-
-      it 'highlights objective-c code by default' do
-        Pygments.should_receive(:pygmentize).with(code, 'objc', '')
-        Syntax.highlight(Snippet.new(code))
-      end
-
-      it 'highlights other languages by filename' do
-        test_language 'swift',  '.swift'
-        test_language 'c++',    '.cc', '.cpp', '.hpp', '.c++', '.cxx'
-        test_language 'objc++', '.mm', '.hh'
-        test_language 'objc',   '.m', '.h'
-        test_language 'dylan',  '.dyl'
-        test_language 'ruby',   '.rb', '.ruby'
-      end
-
-      def test_language(language, *extensions)
-        extensions.each do |extension|
-          Pygments.should_receive(:pygmentize).with(code, language, '')
-          Syntax.highlight(Snippet.new(code, "file#{extension}"))
-        end
-      end
-    end
-
-    context "pygments are not installed" do
-
-      it "prints plain code" do
-        Syntax.stub(:system).and_return(false)
-        Syntax.highlight(snippet).should == 'self.color = [UIColor redColor];'
-      end
-
+      stripped_output = output.gsub(/(?:(?:\u001b\[)|\u009b)(?:(?:[0-9]{1,3})?(?:(?:;[0-9]{0,3})*)?[A-M|f-m])|\u001b[A-M]/, '')
+      stripped_output.should == code
+      stripped_output.should_not == output
     end
   end
 end

--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -26,6 +26,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'rouge', '~> 1.8'
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop", "~> 0.34.0"


### PR DESCRIPTION
This removes a dependency on a Python project, and greatly improves syntax highlighting along with fixing #138.

Before:

![screen shot 2015-05-08 at 18 00 26](https://cloud.githubusercontent.com/assets/44164/7541463/94ffb3f6-f5ad-11e4-8da1-4409002493e4.png)

After:

![screen shot 2015-05-08 at 18 00 11](https://cloud.githubusercontent.com/assets/44164/7541465/9635c29c-f5ad-11e4-8395-f70f1d9bedca.png)

This does add a required dependency which may not be desired, if that is the case I'm happy to amend this pull request to make rouge optional.