### PR TITLE
Disable gems while running

### DIFF
--- a/bin/xcpretty
+++ b/bin/xcpretty
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env ruby --disable-gems
 
 if RUBY_VERSION < '1.8.7'
   abort "error: XCPretty requires Ruby 1.8.7 or higher."


### PR DESCRIPTION
Since xcpretty has no dependencies(!) we don't need to deal with any load path additions. In my quick testing with `time` this cut the CPU time in half on average.

More info [here](http://stackoverflow.com/a/12942955/902968)