### PR TITLE
Improve build target matcher

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -9,55 +9,56 @@ module XCPretty
   module FormatMethods
     EMPTY = ''.freeze
 
-    def format_analyze(file_name, file_path);                 EMPTY; end
-    def format_build_target(target, project, configuration);  EMPTY; end
-    def format_check_dependencies;                            EMPTY; end
-    def format_clean(project, target, configuration);         EMPTY; end
-    def format_clean_target(target, project, configuration);  EMPTY; end
-    def format_clean_remove;                                  EMPTY; end
-    def format_compile(file_name, file_path);                 EMPTY; end
-    def format_compile_command(compiler_command, file_path);  EMPTY; end
-    def format_compile_xib(file_name, file_path);             EMPTY; end
-    def format_copy_header_file(source, target);              EMPTY; end
-    def format_copy_plist_file(source, target);               EMPTY; end
-    def format_copy_strings_file(file_name);                  EMPTY; end
-    def format_cpresource(file);                              EMPTY; end
-    def format_generate_dsym(dsym);                           EMPTY; end
-    def format_linking(file, build_variant, arch);            EMPTY; end
-    def format_libtool(library);                              EMPTY; end
-    def format_passing_test(suite, test, time);               EMPTY; end
-    def format_pending_test(suite, test);                     EMPTY; end
-    def format_measuring_test(suite, test, time);             EMPTY; end
-    def format_failing_test(suite, test, time, file_path);    EMPTY; end
-    def format_process_pch(file);                             EMPTY; end
-    def format_process_pch_command(file_path);                EMPTY; end
-    def format_phase_script_execution(script_name);           EMPTY; end
-    def format_process_info_plist(file_name, file_path);      EMPTY; end
-    def format_codesign(file);                                EMPTY; end
-    def format_preprocess(file);                              EMPTY; end
-    def format_pbxcp(file);                                   EMPTY; end
-    def format_shell_command(command, arguments);             EMPTY; end
-    def format_test_run_started(name);                        EMPTY; end
-    def format_test_run_finished(name, time);                 EMPTY; end
-    def format_test_suite_started(name);                      EMPTY; end
-    def format_test_summary(message, failures_per_suite);     EMPTY; end
-    def format_touch(file_path, file_name);                   EMPTY; end
-    def format_tiffutil(file);                                EMPTY; end
-    def format_write_file(file);                              EMPTY; end
-    def format_write_auxiliary_files;                         EMPTY; end
-
-    # COMPILER / LINKER ERRORS AND WARNINGS
-    def format_compile_error(file_name, file_path, reason,
-                             line, cursor);                   EMPTY; end
-    def format_error(message);                                EMPTY; end
-    def format_undefined_symbols(message, symbol, reference); EMPTY; end
-    def format_duplicate_symbols(message, file_paths);        EMPTY; end
-    def format_warning(message);                            message; end
+    def format_analyze(file_name, file_path);                  EMPTY; end
+    def format_build_target(target, project, configuration);   EMPTY; end
+    def format_analyze_target(target, project, configuration); EMPTY; end
+    def format_check_dependencies;                             EMPTY; end
+    def format_clean(project, target, configuration);          EMPTY; end
+    def format_clean_target(target, project, configuration);   EMPTY; end
+    def format_clean_remove;                                   EMPTY; end
+    def format_compile(file_name, file_path);                  EMPTY; end
+    def format_compile_command(compiler_command, file_path);   EMPTY; end
+    def format_compile_xib(file_name, file_path);              EMPTY; end
+    def format_copy_header_file(source, target);               EMPTY; end
+    def format_copy_plist_file(source, target);                EMPTY; end
+    def format_copy_strings_file(file_name);                   EMPTY; end
+    def format_cpresource(file);                               EMPTY; end
+    def format_generate_dsym(dsym);                            EMPTY; end
+    def format_linking(file, build_variant, arch);             EMPTY; end
+    def format_libtool(library);                               EMPTY; end
+    def format_passing_test(suite, test, time);                EMPTY; end
+    def format_pending_test(suite, test);                      EMPTY; end
+    def format_measuring_test(suite, test, time);              EMPTY; end
+    def format_failing_test(suite, test, time, file_path);     EMPTY; end
+    def format_process_pch(file);                              EMPTY; end
+    def format_process_pch_command(file_path);                 EMPTY; end
+    def format_phase_script_execution(script_name);            EMPTY; end
+    def format_process_info_plist(file_name, file_path);       EMPTY; end
+    def format_codesign(file);                                 EMPTY; end
+    def format_preprocess(file);                               EMPTY; end
+    def format_pbxcp(file);                                    EMPTY; end
+    def format_shell_command(command, arguments);              EMPTY; end
+    def format_test_run_started(name);                         EMPTY; end
+    def format_test_run_finished(name, time);                  EMPTY; end
+    def format_test_suite_started(name);                       EMPTY; end
+    def format_test_summary(message, failures_per_suite);      EMPTY; end
+    def format_touch(file_path, file_name);                    EMPTY; end
+    def format_tiffutil(file);                                 EMPTY; end
+    def format_write_file(file);                               EMPTY; end
+    def format_write_auxiliary_files;                          EMPTY; end
+                                                               
+    # COMPILER / LINKER ERRORS AND WARNINGS                    
+    def format_compile_error(file_name, file_path, reason,     
+                             line, cursor);                    EMPTY; end
+    def format_error(message);                                 EMPTY; end
+    def format_undefined_symbols(message, symbol, reference);  EMPTY; end
+    def format_duplicate_symbols(message, file_paths);         EMPTY; end
+    def format_warning(message);                             message; end
 
     # TODO: see how we can unify format_error and format_compile_error,
     #       the same for warnings
     def format_compile_warning(file_name, file_path, reason,
-                               line, cursor);                 EMPTY; end
+                               line, cursor);                  EMPTY; end
   end
 
   class Formatter

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -27,6 +27,10 @@ module XCPretty
       format("Building", "#{project}/#{target} [#{configuration}]")
     end
 
+    def format_analyze_target(target, project, configuration)
+      format("Building and Analyzing", "#{project}/#{target} [#{configuration}]")
+    end
+
     def format_clean_target(target, project, configuration)
       format("Cleaning", "#{project}/#{target} [#{configuration}]")
     end

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -10,10 +10,11 @@ module XCPretty
     ANALYZE_MATCHER = /^Analyze(?:Shallow)?\s(.*\/(.*\.m))*/
 
     # @regex Captured groups
-    # $1 target
-    # $2 project
-    # $3 configuration
-    BUILD_TARGET_MATCHER = /^=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s===/
+    # $1 action
+    # $2 target
+    # $3 project
+    # $4 configuration
+    BUILD_TARGET_MATCHER = /^=== (BUILD|ANALYZE) TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s===/
 
     # @regex Nothing returned here for now
     CHECK_DEPENDENCIES_MATCHER = /^Check dependencies/
@@ -257,7 +258,7 @@ module XCPretty
       when ANALYZE_MATCHER
         formatter.format_analyze($2, $1)
       when BUILD_TARGET_MATCHER
-        formatter.format_build_target($1, $2, $3)
+        formatter.format_build_target($2, $3, $4)
       when CLEAN_REMOVE_MATCHER
         formatter.format_clean_remove
       when CLEAN_TARGET_MATCHER

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -10,11 +10,16 @@ module XCPretty
     ANALYZE_MATCHER = /^Analyze(?:Shallow)?\s(.*\/(.*\.m))*/
 
     # @regex Captured groups
-    # $1 action
-    # $2 target
-    # $3 project
-    # $4 configuration
-    BUILD_TARGET_MATCHER = /^=== (BUILD|ANALYZE) TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s===/
+    # $1 target
+    # $2 project
+    # $3 configuration
+    BUILD_TARGET_MATCHER = /^=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s===/
+
+    # @regex Captured groups
+    # $1 target
+    # $2 project
+    # $3 configuration
+    ANALYZE_TARGET_MATCHER = /^=== ANALYZE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s===/
 
     # @regex Nothing returned here for now
     CHECK_DEPENDENCIES_MATCHER = /^Check dependencies/
@@ -258,7 +263,9 @@ module XCPretty
       when ANALYZE_MATCHER
         formatter.format_analyze($2, $1)
       when BUILD_TARGET_MATCHER
-        formatter.format_build_target($2, $3, $4)
+        formatter.format_build_target($1, $2, $3)
+      when ANALYZE_TARGET_MATCHER
+        formatter.format_analyze_target($1, $2, $3)
       when CLEAN_REMOVE_MATCHER
         formatter.format_clean_remove
       when CLEAN_TARGET_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -22,6 +22,7 @@ SAMPLE_OLD_SPECTA_FAILURE = "/Users/musalj/code/OSS/ReactiveCocoa/ReactiveCocoaF
 SAMPLE_SPECTA_FAILURE = "         Test Case '-[SKWelcomeViewControllerSpecSpec SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen]' started. \n/Users/vickeryj/Code/ipad-register/KIFTests/Specs/SKWelcomeViewControllerSpec.m:11: error: -[SKWelcomeViewControllerSpecSpec SKWelcomeViewController_When_a_user_opens_the_app_from_a_clean_installation_displays_the_welcome_screen] : The step timed out after 2.00 seconds: Failed to find accessibility element with the label \"The asimplest way to make smarter business decisions\""
 
 SAMPLE_BUILD = "=== BUILD TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ==="
+SAMPLE_ANALYZE_TARGET = "=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ==="
 SAMPLE_CLEAN = "=== CLEAN TARGET Pods-ObjectiveSugar OF PROJECT Pods WITH CONFIGURATION Debug ==="
 SAMPLE_ANOTHER_CLEAN = "=== CLEAN TARGET Pods OF PROJECT Pods WITH CONFIGURATION Debug ==="
 SAMPLE_CLEAN_REMOVE = %Q(

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -20,6 +20,11 @@ module XCPretty
         "> Building Pods/The Spacer [Debug]"
       end
 
+      it "formats analyze target/project/configuration with target" do
+        @formatter.format_analyze_target("The Spacer", "Pods", "Debug").should ==
+        "> Building and Analyzing Pods/The Spacer [Debug]"
+      end
+
       it "formats clean target/project/configuration" do
         @formatter.format_clean_target("Pods-ObjectiveSugar", "Pods", "Debug").should ==
         "> Cleaning Pods/Pods-ObjectiveSugar [Debug]"

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -29,7 +29,7 @@ module XCPretty
     end
 
     it "parses analyze target" do
-      @formatter.should receive(:format_build_target).with("The Spacer", "Pods", "Debug")
+      @formatter.should receive(:format_analyze_target).with("The Spacer", "Pods", "Debug")
       @parser.parse(SAMPLE_ANALYZE_TARGET)
     end
 

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -28,6 +28,11 @@ module XCPretty
       @parser.parse(SAMPLE_BUILD)
     end
 
+    it "parses analyze target" do
+      @formatter.should receive(:format_build_target).with("The Spacer", "Pods", "Debug")
+      @parser.parse(SAMPLE_ANALYZE_TARGET)
+    end
+
     it "parses clean remove" do
       @formatter.should receive(:format_clean_remove)
       @parser.parse(SAMPLE_CLEAN_REMOVE)


### PR DESCRIPTION
When xcodebuild is run with `RUN_CLANG_STATIC_ANALYZER=YES` it outputs `=== ANALYZE TARGET` instead of `=== BUILD TARGET`. It is still actually building the target.