### PR TITLE
Fixed not showing ld error messages

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -210,7 +210,7 @@ module XCPretty
       FATAL_ERROR_MATCHER = /^(fatal error:.*)$/
 
       # $1 = whole error
-      LD_ERROR_MATCHER = /^(ld:.*not found for.*)/
+      LD_ERROR_MATCHER = /^(ld:.*)/
 
       # @regex Captured groups
       # $1 file path

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -553,6 +553,11 @@ ld: 1 duplicate symbol for architecture i386
 clang: error: linker command failed with exit code 1 (use -v to see invocation)
 )
 
+SAMPLE_BITCODE_LD = %Q(
+ld: '/Users/.../GoogleAnalytics-iOS-SDK/libGoogleAnalyticsServices.a(TAGHit.o)' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. for architecture armv7
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+)
+
 SAMPLE_LD_SYMBOLS_ERROR = 'ld: symbol(s) not found for architecture x86_64'
 SAMPLE_LD_LIBRARY_ERROR = 'ld: library not found for -lPods-Yammer'
 

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -555,7 +555,6 @@ clang: error: linker command failed with exit code 1 (use -v to see invocation)
 
 SAMPLE_BITCODE_LD = %Q(
 ld: '/Users/.../GoogleAnalytics-iOS-SDK/libGoogleAnalyticsServices.a(TAGHit.o)' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. for architecture armv7
-clang: error: linker command failed with exit code 1 (use -v to see invocation)
 )
 
 SAMPLE_LD_SYMBOLS_ERROR = 'ld: symbol(s) not found for architecture x86_64'

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -164,6 +164,14 @@ module XCPretty
       @parser.parse(SAMPLE_OLD_SPECTA_FAILURE)
     end
 
+    it "parses ld bitcode errors" do
+      @formatter.should receive(:format_error).with(SAMPLE_BITCODE_LD.split("\n")[1])
+      @formatter.should receive(:format_error).with(SAMPLE_BITCODE_LD.split("\n")[2])
+      SAMPLE_BITCODE_LD.each_line do |line|
+        @parser.parse(line)
+      end
+    end
+
     it "parses passing ocunit tests" do
       @formatter.should receive(:format_passing_test).with('RACCommandSpec',
                                                            'enabled_signal_should_send_YES_while_executing_is_YES_and_allowsConcurrentExecution_is_YES',

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -165,11 +165,8 @@ module XCPretty
     end
 
     it "parses ld bitcode errors" do
-      @formatter.should receive(:format_error).with(SAMPLE_BITCODE_LD.split("\n")[1])
-      @formatter.should receive(:format_error).with(SAMPLE_BITCODE_LD.split("\n")[2])
-      SAMPLE_BITCODE_LD.each_line do |line|
-        @parser.parse(line)
-      end
+      @formatter.should receive(:format_error).with(SAMPLE_BITCODE_LD.strip)
+      @parser.parse(SAMPLE_BITCODE_LD)
     end
 
     it "parses passing ocunit tests" do


### PR DESCRIPTION
Fixes https://github.com/supermarin/xcpretty/issues/152

This will change the output on a Bitcode failure from 

```
⌦  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
to
```
⌦  ld: '/Users/felixkrause/Developer/Moto Deals/Pods/GoogleAnalytics-iOS-SDK/libGoogleAnalyticsServices.a(TAGHit.o)' does not contain bitcode. You must rebuild it with bitcode enabled (Xcode setting ENABLE_BITCODE), obtain an updated library from the vendor, or disable bitcode for this target. for architecture armv7

⌦  clang: error: linker command failed with exit code 1 (use -v to see invocation)
```