### PR TITLE
Use the CROSS MARK (U+274C) symbol for errors

### DIFF
--- a/features/steps/formatting_steps.rb
+++ b/features/steps/formatting_steps.rb
@@ -251,7 +251,7 @@ Then(/^I should not see the name of the test group$/) do
 end
 
 Then(/^I should see a red error message$/) do
-  run_output.should include(red("⌦  " + SAMPLE_PODS_ERROR.gsub('error: ', '')))
+  run_output.should include(red("❌  " + SAMPLE_PODS_ERROR.gsub('error: ', '')))
 end
 
 Then(/^I should see a yellow warning message$/) do
@@ -272,7 +272,7 @@ Then(/^I should see a cyan cursor$/) do
 end
 
 Then(/^I should see the undefined symbold message$/) do
-  run_output.should include(red("⌦  Undefined symbols for architecture x86_64"))
+  run_output.should include(red("❌  Undefined symbols for architecture x86_64"))
 end
 
 Then(/^I should see the symbol and reference that caused failure$/) do

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -97,7 +97,7 @@ module XCPretty
       "\n\n#{text}"
     end
 
-    ERROR = '⌦ '
+    ERROR = '❌ '
     ASCII_ERROR = '[x]'
 
     WARNING = '⚠️ '

--- a/spec/xcpretty/formatters/formatter_spec.rb
+++ b/spec/xcpretty/formatters/formatter_spec.rb
@@ -25,7 +25,7 @@ module XCPretty
 
     it "formats cocoapods errors" do
       @formatter.format_error("The sandbox is not in sync...").should ==
-      "\n#{@formatter.red("⌦  The sandbox is not in sync...")}\n\n"
+      "\n#{@formatter.red("❌  The sandbox is not in sync...")}\n\n"
     end
 
     it "formats compiling errors" do
@@ -33,7 +33,7 @@ module XCPretty
                                       "[a should",
                                       "         ^").should ==
 %Q(
-#{@formatter.red('⌦  ')}path/to/file: #{@formatter.red("expected valid syntax")}
+#{@formatter.red('❌  ')}path/to/file: #{@formatter.red("expected valid syntax")}
 
 [a should
 #{@formatter.cyan("         ^")}
@@ -61,7 +61,7 @@ module XCPretty
       @formatter.format_undefined_symbols("Undefined symbols for architecture x86_64",
                                           '_OBJC_CLASS_$_CABasicAnimation',
                                           'objc-class-ref in ATZRadialProgressControl.o').should == %Q(
-#{@formatter.red("⌦  Undefined symbols for architecture x86_64")}
+#{@formatter.red("❌  Undefined symbols for architecture x86_64")}
 > Symbol: _OBJC_CLASS_$_CABasicAnimation
 > Referenced from: objc-class-ref in ATZRadialProgressControl.o
 
@@ -72,7 +72,7 @@ module XCPretty
       @formatter.format_duplicate_symbols("duplicate symbol _OBJC_IVAR_$ClassName._ivarName in",
         ['/Users/username/Library/Developer/Xcode/DerivedData/App-arcyyktezaigixbocjwfhsjllojz/Build/Intermediates/App.build/Debug-iphonesimulator/App.build/Objects-normal/i386/ClassName.o',
          '/Users/username/Library/Developer/Xcode/DerivedData/App-arcyyktezaigixbocjwfhsjllojz/Build/Products/Debug-iphonesimulator/libPods.a(DuplicateClassName.o)']).should == %Q(
-#{@formatter.red("⌦  duplicate symbol _OBJC_IVAR_$ClassName._ivarName in")}
+#{@formatter.red("❌  duplicate symbol _OBJC_IVAR_$ClassName._ivarName in")}
 > ClassName.o
 > libPods.a(DuplicateClassName.o)
 )


### PR DESCRIPTION
I always thought that the `⌦` symbol was a glitch rather than the expected symbol for errors.