### PR TITLE
Format phase success

### DIFF
--- a/features/simple_format.feature
+++ b/features/simple_format.feature
@@ -15,6 +15,11 @@ Feature: Showing build output in simple format
         When I pipe to xcpretty with "--simple"
         Then I should see a successful precompilation message
 
+    Scenario: Showing phase success
+        Given I have completed a build
+        When I pipe to xcpretty with "--simple"
+        Then I should see a "build" completion message
+
     Scenario: Showing file compilation with color
         Given I have a file to compile
         When I pipe to xcpretty with "--simple --color"

--- a/features/steps/formatting_steps.rb
+++ b/features/steps/formatting_steps.rb
@@ -108,6 +108,18 @@ Given(/^I have an unrelated image in the output folder/) do
   copy_file_to_screenshot_dir(SAMPLE_UNRELATED_IMAGE_FILE)
 end
 
+Given(/^I have completed a build$/) do
+  add_run_input SAMPLE_BUILD_SUCCEEDED
+end
+
+Given(/^I have completed a clean$/) do
+  add_run_input SAMPLE_CLEAN_SUCCEEDED
+end
+
+Then(/^I should see a "(\w+)" completion message$/) do |phase|
+  run_output.should start_with("▸ #{phase.capitalize} Succeeded")
+end
+
 Then(/^I should see text beginning with "(.*?)"$/) do |text|
   run_output.lines.to_a.detect {|line| line.start_with? text }.should_not be_nil
 end

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -32,6 +32,7 @@ module XCPretty
     def format_failing_test(suite, test, time, file_path);     EMPTY; end
     def format_process_pch(file);                              EMPTY; end
     def format_process_pch_command(file_path);                 EMPTY; end
+    def format_phase_success(phase_name);                      EMPTY; end
     def format_phase_script_execution(script_name);            EMPTY; end
     def format_process_info_plist(file_name, file_path);       EMPTY; end
     def format_codesign(file);                                 EMPTY; end

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -8,11 +8,11 @@ module XCPretty
     PASS = "✓"
     FAIL = "✗"
     PENDING = "⧖"
+    COMPLETION = "▸"
     MEASURE = '◷'
 
     ASCII_PASS = "."
     ASCII_FAIL = "x"
-    COMPLETION = "▸"
     ASCII_PENDING = "P"
     ASCII_COMPLETION = ">"
     ASCII_MEASURE = 'T'

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -89,6 +89,10 @@ module XCPretty
       )
     end
 
+    def format_phase_success(phase_name)
+      format(phase_name.capitalize, "Succeeded")
+    end
+
     def format_phase_script_execution(script_name)
       format("Running script", "'#{script_name}'")
     end

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -120,6 +120,8 @@ module XCPretty
     # $3 = time
     MEASURING_TEST_MATCHER = /^[^:]*:[^:]*:\sTest Case\s'-\[(.*)\s(.*)\]'\smeasured\s\[Time,\sseconds\]\saverage:\s(\d*\.\d{3}),/
 
+    PHASE_SUCCESS_MATCHER = /^\*\*\s(.*)\sSUCCEEDED\s\*\*/
+
     # @regex Captured groups
     # $1 = script_name
     PHASE_SCRIPT_EXECUTION_MATCHER = /^PhaseScriptExecution\s(.*)\s\//
@@ -320,6 +322,8 @@ module XCPretty
         formatter.format_process_info_plist(*unescaped($2, $1))
       when PHASE_SCRIPT_EXECUTION_MATCHER
         formatter.format_phase_script_execution(*unescaped($1))
+      when PHASE_SUCCESS_MATCHER
+        formatter.format_phase_success($1)
       when PROCESS_PCH_MATCHER
         formatter.format_process_pch($1)
         when PROCESS_PCH_COMMAND_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -25,6 +25,8 @@ SAMPLE_BUILD = "=== BUILD TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CON
 SAMPLE_ANALYZE_TARGET = "=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ==="
 SAMPLE_CLEAN = "=== CLEAN TARGET Pods-ObjectiveSugar OF PROJECT Pods WITH CONFIGURATION Debug ==="
 SAMPLE_ANOTHER_CLEAN = "=== CLEAN TARGET Pods OF PROJECT Pods WITH CONFIGURATION Debug ==="
+SAMPLE_BUILD_SUCCEEDED = "** BUILD SUCCEEDED **"
+SAMPLE_CLEAN_SUCCEEDED = "** CLEAN SUCCEEDED **"
 SAMPLE_CLEAN_REMOVE = %Q(
 Clean.Remove clean /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugarTests.build
     builtin-rm -rf /Users/musalj/Library/Developer/Xcode/DerivedData/ObjectiveSugar-ayzdhqmmwtqgysdpznmovjlupqjy/Build/Intermediates/ObjectiveSugar.build/Debug-iphonesimulator/ObjectiveSugarTests.build

--- a/spec/xcpretty/formatters/simple_spec.rb
+++ b/spec/xcpretty/formatters/simple_spec.rb
@@ -105,6 +105,14 @@ module XCPretty
         "    T _tupleByAddingObject__should_add_a_non_nil_object measured (0.001 seconds)"
       end
 
+      it "formats build success output" do
+        @formatter.format_phase_success("BUILD").should == "> Build Succeeded"
+      end
+
+      it "formats clean success output" do
+        @formatter.format_phase_success("CLEAN").should == "> Clean Succeeded"
+      end
+
       it "formats Phase Script Execution" do
         @formatter.format_phase_script_execution("Check Pods Manifest.lock").should ==
         "> Running script 'Check Pods Manifest.lock'"

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -198,6 +198,16 @@ module XCPretty
       @parser.parse(SAMPLE_MEASURING_TEST)
     end
 
+    it "parses build success indicator" do
+      @formatter.should receive(:format_phase_success).with('BUILD')
+      @parser.parse(SAMPLE_BUILD_SUCCEEDED)
+    end
+
+    it "parses clean success indicator" do
+      @formatter.should receive(:format_phase_success).with('CLEAN')
+      @parser.parse(SAMPLE_CLEAN_SUCCEEDED)
+    end
+
     it "parses PhaseScriptExecution" do
       @formatter.should receive(:format_phase_script_execution).with('Check Pods Manifest.lock')
       @parser.parse(SAMPLE_RUN_SCRIPT)

--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2"
-  spec.add_development_dependency "cucumber", "~> 1"
+  spec.add_development_dependency "rspec", "~> 2.0"
+  spec.add_development_dependency "cucumber", "~> 1.0"
 end


### PR DESCRIPTION
Fixes #166 

Split off from #118, formats build/test/clean succeeded messages. Does not handle failure, since that prints to stderr anyway.