### PR TITLE
s/INPUT_RECORD_SEPARATOR/\//

### DIFF
--- a/xcpretty.gemspec
+++ b/xcpretty.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/supermarin/xcpretty"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Seems like this was nil and was breaking `gem build`
Fixes https://github.com/supermarin/xcpretty/issues/172

cc/ @kattrali @0xced