### PR TITLE
Add format_ld_warning default implementation

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -54,6 +54,7 @@ module XCPretty
                              line, cursor);                    EMPTY; end
     def format_error(message);                                 EMPTY; end
     def format_file_missing_error(error, file_path);           EMPTY; end
+    def format_ld_warning(message);                            EMPTY; end
     def format_undefined_symbols(message, symbol, reference);  EMPTY; end
     def format_duplicate_symbols(message, file_paths);         EMPTY; end
     def format_warning(message);                             message; end


### PR DESCRIPTION
Since commit 77e7091, the format_ld_warning method has been introduced without its default implementation (added now).