### PR TITLE
Fixes #193 - avoid setting include directives to empty paths

### DIFF
--- a/features/json_compilation_database_report.feature
+++ b/features/json_compilation_database_report.feature
@@ -19,3 +19,8 @@ Feature: Create a JSON compilation database
     Scenario: Writing to multiple custom file paths
         When I pipe to xcpretty with two custom "json-compilation-database" report paths
         Then I should have JSON compilation databases in two custom paths
+
+    Scenario: A project with dependencies with no .pch file
+        Given some big input
+        When I pipe to xcpretty with "--report json-compilation-database" and specify a custom path
+        Then entries with a command shouldn't have malformed "-include" directives

--- a/features/steps/json_steps.rb
+++ b/features/steps/json_steps.rb
@@ -35,3 +35,7 @@ Then(/^the JSON compilation database should be complete$/) do
   entries.length.should == JSON_DB_FIXTURE_COMMAND_COUNT
 end
 
+Then(/^entries with a command shouldn't have malformed "-include" directives$/) do
+  entries = json_db.select { |entry| entry['command'].match(/-include\s+-/) }
+  entries.length.should == 0
+end

--- a/lib/xcpretty/reporters/json_compilation_database.rb
+++ b/lib/xcpretty/reporters/json_compilation_database.rb
@@ -39,7 +39,10 @@ module XCPretty
     def format_compile_command(compiler_command, file_path)
       directory = file_path.gsub("#{@current_path}", '').gsub(/\/$/, '')
       directory = '/' if directory.empty?
-      cmd = compiler_command.gsub(/(\-include)\s.*\.pch/, "\\1 #{@pch_path}")
+
+      cmd = compiler_command
+      cmd = compiler_command.gsub(/(\-include)\s.*\.pch/, "\\1 #{@pch_path}") if @pch_path
+
       @compilation_units << {command: cmd,
                              file: @current_path,
                              directory: directory}

--- a/lib/xcpretty/reporters/json_compilation_database.rb
+++ b/lib/xcpretty/reporters/json_compilation_database.rb
@@ -41,7 +41,7 @@ module XCPretty
       directory = '/' if directory.empty?
 
       cmd = compiler_command
-      cmd = compiler_command.gsub(/(\-include)\s.*\.pch/, "\\1 #{@pch_path}") if @pch_path
+      cmd = cmd.gsub(/(\-include)\s.*\.pch/, "\\1 #{@pch_path}") if @pch_path
 
       @compilation_units << {command: cmd,
                              file: @current_path,


### PR DESCRIPTION
If no .pch file is processed before compiling a .c file, the JSON
compilation database formatter would replace `-include` directives using
empty paths. This casues tools like OCLint to fail when building those
files.