### PR TITLE
Formatter.finish: give formatters the ability to know the end

### DIFF
--- a/bin/xcpretty
+++ b/bin/xcpretty
@@ -81,5 +81,6 @@ STDIN.each_line do |line|
   reporters.each { |r| r.handle(line) }
 end
 
+printer.finish
 reporters.each(&:finish)
 

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -78,6 +78,9 @@ module XCPretty
       @parser = Parser.new(self)
     end
 
+    def finish
+    end
+
     # Override if you want to catch something specific with your regex
     def pretty_format(text)
       parser.parse(text)

--- a/lib/xcpretty/printer.rb
+++ b/lib/xcpretty/printer.rb
@@ -11,6 +11,10 @@ module XCPretty
       @formatter = klass.new(params[:unicode], params[:colorize])
     end
 
+    def finish
+      @formatter.finish
+    end
+
     def pretty_print(text)
       formatted_text = formatter.pretty_format(text)
       unless formatted_text.empty?


### PR DESCRIPTION
I was trying to write a formatter that outputs in JSON format, but needed to know the end of the parsing.