### PR TITLE
Fixing PhaseScriptExecution regex

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -129,7 +129,7 @@ module XCPretty
 
     # @regex Captured groups
     # $1 = script_name
-    PHASE_SCRIPT_EXECUTION_MATCHER = /^PhaseScriptExecution\s(.*)\s\//
+    PHASE_SCRIPT_EXECUTION_MATCHER = /^PhaseScriptExecution\s(.*)\s/
 
     # @regex Captured groups
     # $1 = file

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -129,7 +129,7 @@ module XCPretty
 
     # @regex Captured groups
     # $1 = script_name
-    PHASE_SCRIPT_EXECUTION_MATCHER = /^PhaseScriptExecution\s(.*)\s/
+    PHASE_SCRIPT_EXECUTION_MATCHER = /^PhaseScriptExecution\s((\\\ |\S)*)\s/
 
     # @regex Captured groups
     # $1 = file


### PR DESCRIPTION
PHASE_SCRIPT_EXECUTION_MATCHER was expecting an extra "/" at the end of its match.  This was preventing successful matches, causing the "Run Script" phase to not be shown. This fixes issue 163 (https://github.com/supermarin/xcpretty/issues/163)