### PR TITLE
Add name attribute to root node in junit reporter.

### DIFF
--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -30,6 +30,10 @@ module XCPretty
       @parser.parse(line)
     end
 
+    def format_test_run_started(name)
+      @document.root.add_attribute('name', name)
+    end
+
     def format_passing_test(classname, test_case, time)
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname

--- a/spec/xcpretty/reporters/junit_spec.rb
+++ b/spec/xcpretty/reporters/junit_spec.rb
@@ -1,21 +1,19 @@
 require 'xcpretty'
+require 'tempfile'
 
 module XCPretty
   describe JUnit do
     before(:each) do
-      @reporterFile = Tempfile.new('junit')
-      @formatter = JUnit.new({path: @reporterFile.path})
+      @reporter_file = Tempfile.new('junit')
+      @formatter = JUnit.new(path: @reporter_file.path)
     end
 
     it "has name attribute in root node" do
       test_name = "ReactiveCocoaTests.xctest"
       @formatter.format_test_run_started(test_name)
       @formatter.finish
-
-      document  = REXML::Document.new(@reporterFile)
+      document = REXML::Document.new(@reporter_file)
       document.root.attributes['name'].should == test_name
     end
   end
 end
-
-

--- a/spec/xcpretty/reporters/junit_spec.rb
+++ b/spec/xcpretty/reporters/junit_spec.rb
@@ -1,0 +1,21 @@
+require 'xcpretty'
+
+module XCPretty
+  describe JUnit do
+    before(:each) do
+      @reporterFile = Tempfile.new('junit')
+      @formatter = JUnit.new({path: @reporterFile.path})
+    end
+
+    it "has name attribute in root node" do
+      test_name = "ReactiveCocoaTests.xctest"
+      @formatter.format_test_run_started(test_name)
+      @formatter.finish
+
+      document  = REXML::Document.new(@reporterFile)
+      document.root.attributes['name'].should == test_name
+    end
+  end
+end
+
+


### PR DESCRIPTION
The junit reporter doesn't assign a name to the root node of the xml
document. As such, on systems like jenkins a confusing label of '(root)' is
displayed when viewing test results. This commit changes that to use the
name provided by format_test_run_started.

![screen shot 2016-01-04 at 5 52 58 pm](https://cloud.githubusercontent.com/assets/470767/12105783/e30b9322-b30c-11e5-80a7-828eb4f31721.png)
