### PR TITLE
Add the JUnit `time` attribute on a failed tests.

### DIFF
--- a/features/steps/junit_steps.rb
+++ b/features/steps/junit_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I should see a failed test node in my report$/) do
   junit_report_root.elements.to_a.detect do |node|
     element = node.elements.to_a.first
-    element && element.name == "failure"
+    element && element.name == "failure" && node.attributes["time"] != nil
   end.should_not be_nil
 end
 

--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -54,6 +54,8 @@ module XCPretty
       test_node = suite(classname).add_element('testcase')
       test_node.attributes['classname'] = classname
       test_node.attributes['name']      = test_case
+      # A fake time is added to let Sonar parse failed tests.
+      test_node.attributes['time']      = "0"
       fail_node = test_node.add_element('failure')
       fail_node.attributes['message'] = reason
       fail_node.text = file.sub(@directory + '/', '')


### PR DESCRIPTION
The Sonar JUnit parser fails if the `time` attribute is not present on
failed tests. This patch adds this attribute for these tests with a
fixed duration of "0".

Adding the real test duration was considered however it cannot be
done easily with the current xcpretty implementation:  xcpretty parses
Xcode output line by line whereas a failed test outputs at least 2 lines
of log: one that shows the failed test and the cause, another that
displays the duration (quite the same line as a passing test).
A considered approach would be to keep a context and output a
transformed log line only if the context is full (in the case of failed
tests, only if the cause and the duration have been parsed).