### PR TITLE
Adding an unmatched text formatter.  

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -63,6 +63,8 @@ module XCPretty
     #       the same for warnings
     def format_compile_warning(file_name, file_path, reason,
                                line, cursor);                  EMPTY; end
+
+    def format_unmatched(message);                           message; end
   end
 
   class Formatter
@@ -142,6 +144,11 @@ module XCPretty
     def format_duplicate_symbols(message, file_paths)
       "\n#{red(error_symbol + " " + message)}\n" \
         "> #{file_paths.map { |path| path.split('/').last }.join("\n> ")}\n"
+    end
+
+    def format_unmatched(message)
+      # Do nothing. This function is meant to be overloaded.
+      ""
     end
 
 

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -372,7 +372,7 @@ module XCPretty
       when GENERIC_WARNING_MATCHER
         formatter.format_warning($1)
       else
-        ""
+        formatter.format_unmatched(text)
       end
     end
 


### PR DESCRIPTION
There is no difference in base behavior, but exposes unmatched text to custom formatters.  This allows a user to output and format nonstandard output, such as from scripts.