### PR TITLE
Add support for custom compiler toolchains

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -60,7 +60,7 @@ module XCPretty
     # @regex Captured groups
     # $1 compiler_command
     # $2 file_path
-    COMPILE_COMMAND_MATCHER = /^\s*(.*\/usr\/bin\/clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$/
+    COMPILE_COMMAND_MATCHER = /^\s*(.*\/bin\/clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$/
 
     # @regex Captured groups
     # $1 file_path


### PR DESCRIPTION
Projects may decide to use their own compiler toolchain for building,
in which case the path to the clang executable will likely not contain
the /usr prefix. This commit thus removes that prefix from the
corresponding matcher.