### PR TITLE
Fixed issue where the wrong syntax formatter was being used for HTML

### DIFF
--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -38,7 +38,7 @@ module XCPretty
 
     def formatted_snippet(filepath)
       snippet = Snippet.from_filepath(filepath)
-      Syntax.highlight(snippet)
+      Syntax.highlight_html(snippet)
     end
 
 

--- a/lib/xcpretty/syntax.rb
+++ b/lib/xcpretty/syntax.rb
@@ -12,12 +12,12 @@ module XCPretty
   module Syntax
     def self.highlight(snippet)
       return snippet.contents unless Rouge
-      self.highlight_with_formatter(snippet, Rouge::Formatters::Terminal256.new)
+      highlight_with_formatter(snippet, Rouge::Formatters::Terminal256.new)
     end
 
     def self.highlight_html(snippet)
       return snippet.contents unless Rouge
-      self.highlight_with_formatter(snippet, Rouge::Formatters::HTML.new)
+      highlight_with_formatter(snippet, Rouge::Formatters::HTML.new)
     end
 
     def self.highlight_with_formatter(snippet, formatter)

--- a/lib/xcpretty/syntax.rb
+++ b/lib/xcpretty/syntax.rb
@@ -12,7 +12,15 @@ module XCPretty
   module Syntax
     def self.highlight(snippet)
       return snippet.contents unless Rouge
+      self.highlight_with_formatter(snippet, Rouge::Formatters::Terminal256.new)
+    end
 
+    def self.highlight_html(snippet)
+      return snippet.contents unless Rouge
+      self.highlight_with_formatter(snippet, Rouge::Formatters::HTML.new)
+    end
+
+    def self.highlight_with_formatter(snippet, formatter)
       if snippet.file_path.include?(':')
         filename = snippet.file_path.rpartition(':').first
       else
@@ -21,7 +29,6 @@ module XCPretty
 
       lexer = find_lexer(filename, snippet.contents)
       if lexer
-        formatter = Rouge::Formatters::Terminal256.new
         formatter.format(lexer.lex(snippet.contents))
       else
         snippet.contents


### PR DESCRIPTION
The wrong formatter was being used for HTML output, leading to ANSI escape codes being inserted.

Fixes this issue #195 