### PR TITLE
Handle 'TargetName will not be code signed because' warning

### DIFF
--- a/features/simple_format.feature
+++ b/features/simple_format.feature
@@ -167,6 +167,11 @@ Feature: Showing build output in simple format
         When I pipe to xcpretty with "--simple --no-color"
         Then I should see a successful code signing message
 
+    Scenario: Showing target will not be code signed warning
+        Given I have a target which will not be code signed
+        When I pipe to xcpretty with "--simple --color"
+        Then I should see a target will not be code signed warning
+
     Scenario: Showing preprocess
         Given I have a file to preprocess
         When I pipe to xcpretty with "--simple --no-color"
@@ -206,4 +211,3 @@ Feature: Showing build output in simple format
         Given there were warnings in the code
         When I pipe to xcpretty with "--simple --color"
         Then I should see a yellow warning message
-

--- a/features/steps/formatting_steps.rb
+++ b/features/steps/formatting_steps.rb
@@ -68,6 +68,10 @@ Given(/^I have a framework to code sign$/) do
   add_run_input SAMPLE_CODESIGN_FRAMEWORK
 end
 
+Given(/^I have a target which will not be code signed$/) do
+  add_run_input SAMPLE_WILL_NOT_BE_CODE_SIGNED
+end
+
 Given(/^I have a file to preprocess$/) do
   add_run_input SAMPLE_PREPROCESS
 end
@@ -183,6 +187,10 @@ end
 
 Then(/^I should see a successful code signing message$/) do
   run_output.should start_with("▸ Signing")
+end
+
+Then(/^I should see a target will not be code signed warning$/) do
+  run_output.should include(yellow("⚠️  FrameworkName will not be code signed because its settings don't specify a development team."))
 end
 
 Then(/^I should see a successful preprocessing message$/) do
@@ -335,4 +343,3 @@ end
 Then(/^I should see text matching "(.*?)"$/) do |text|
   run_output.lines.to_a.last.strip.should == text
 end
-

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -148,6 +148,10 @@ module XCPretty
         "> #{file_paths.map { |path| path.split('/').last }.join("\n> ")}\n"
     end
 
+    def format_will_not_be_code_signed(message)
+      "#{yellow(warning_symbol + " " + message)}"
+    end
+
 
     private
 

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -211,6 +211,10 @@ module XCPretty
       # @regex Captured groups
       # $1 = whole warning
       GENERIC_WARNING_MATCHER = /^warning:\s(.*)$/
+
+      # @regex Captured groups
+      # $1 = whole warning
+      WILL_NOT_BE_CODE_SIGNED_MATCHER = /^(.* will not be code signed because .*)$/
     end
 
     module Errors
@@ -396,6 +400,8 @@ module XCPretty
         formatter.format_shell_command($1, $2)
       when GENERIC_WARNING_MATCHER
         formatter.format_warning($1)
+      when WILL_NOT_BE_CODE_SIGNED_MATCHER
+        formatter.format_will_not_be_code_signed($1)
       else
         ""
       end

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -615,3 +615,5 @@ SAMPLE_FORMAT_WARNING = %Q(
                          %d
 1 warning generated.
 )
+
+SAMPLE_WILL_NOT_BE_CODE_SIGNED = "FrameworkName will not be code signed because its settings don't specify a development team."

--- a/spec/xcpretty/formatters/formatter_spec.rb
+++ b/spec/xcpretty/formatters/formatter_spec.rb
@@ -91,6 +91,10 @@ module XCPretty
 )
     end
 
+    it "formats will not be code signed warnings" do
+      @formatter.format_will_not_be_code_signed(SAMPLE_WILL_NOT_BE_CODE_SIGNED).should == "#{@formatter.yellow("⚠️  FrameworkName will not be code signed because its settings don't specify a development team.")}"
+    end
+
 
     it "formats failures per suite" do
         Syntax.stub(:highlight) { |snippet| snippet.contents }
@@ -137,4 +141,3 @@ StringSpec
     end
   end
 end
-

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -492,6 +492,11 @@ module XCPretty
         @formatter.should receive(:format_ld_warning).with("ld: embedded dylibs/frameworks only run on iOS 8 or later")
         @parser.parse("ld: warning: embedded dylibs/frameworks only run on iOS 8 or later")
       end
+
+      it "parses will not be code signed warnings" do
+        @formatter.should receive(:format_will_not_be_code_signed).with(SAMPLE_WILL_NOT_BE_CODE_SIGNED)
+        @parser.parse(SAMPLE_WILL_NOT_BE_CODE_SIGNED)
+      end
     end
 
     context "summary" do


### PR DESCRIPTION
This will handle 'TargetName will not be code signed because ...' warnings and display them like this:

![image](https://cloud.githubusercontent.com/assets/350654/19210253/fbdd07c8-8d68-11e6-8678-33d251339527.png)
