### PR TITLE
Improve Code sign error checking

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -224,15 +224,7 @@ module XCPretty
 
       # @regex Captured groups
       # $1 = whole error
-      CODESIGN_ERROR_MATCHER = /^(Code\s?Sign error:.*)$/
-
-      # @regex Captured groups
-      # $1 = whole error
-      CODE_SIGNING_REQUIRED_MATCHER = /^(Code signing is required for product type .* in SDK .*)$/
-
-      # @regex Captured groups
-      # #1 = whole error
-      NO_PROFILE_MATCHING_MATCHER = /^(No profile matching .* found:.*)$/
+      CHECK_DEPENDENCIES_ERRORS_MATCHER = /^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*)$/
 
       # @regex Captured groups
       # $1 = whole error
@@ -251,10 +243,6 @@ module XCPretty
       # @regex Captured groups
       # $1 cursor (with whitespaces and tildes)
       CURSOR_MATCHER = /^([\s~]*\^[\s~]*)$/
-
-      # @regex Captured groups
-      # $1 = whole message
-      PROFILE_DOESNT_SUPPORT_OR_INCLUDE = /^(Provisioning profile .* doesn't .*)$/
 
       # @regex Captured groups
       # $1 = whole error.
@@ -340,11 +328,7 @@ module XCPretty
         formatter.format_codesign($1)
       when CODESIGN_MATCHER
         formatter.format_codesign($1)
-      when CODESIGN_ERROR_MATCHER
-        formatter.format_error($1)
-      when CODE_SIGNING_REQUIRED_MATCHER
-        formatter.format_error($1)
-      when NO_PROFILE_MATCHING_MATCHER
+      when CHECK_DEPENDENCIES_ERRORS_MATCHER
         formatter.format_error($1)
       when PROVISIONING_PROFILE_REQUIRED_MATCHER
         formatter.format_error($1)
@@ -364,8 +348,6 @@ module XCPretty
         formatter.format_copy_plist_file($1, $2)
       when CPRESOURCE_MATCHER
         formatter.format_cpresource($1)
-      when PROFILE_DOESNT_SUPPORT_OR_INCLUDE
-        formatter.format_error($1)
       when EXECUTED_MATCHER
         format_summary_if_needed(text)
       when UI_FAILING_TEST_MATCHER

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -224,7 +224,7 @@ module XCPretty
 
       # @regex Captured groups
       # $1 = whole error
-      CHECK_DEPENDENCIES_ERRORS_MATCHER = /^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*)$/
+      CHECK_DEPENDENCIES_ERRORS_MATCHER = /^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$/
 
       # @regex Captured groups
       # $1 = whole error

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -235,6 +235,14 @@ module XCPretty
       NO_PROFILE_MATCHING_MATCHER = /^(No profile matching .* found:.*)$/
 
       # @regex Captured groups
+      # $1 = whole error
+      PROVISIONING_PROFILE_REQUIRED_MATCHER = /^(.*requires a provisioning profile.*)$/
+
+      # @regex Captured groups
+      # $1 = whole error
+      NO_CERTIFICATE_MATCHER = /^(No certificate matching.*)$/
+
+      # @regex Captured groups
       # $1 = file_path
       # $2 = file_name
       # $3 = reason
@@ -337,6 +345,10 @@ module XCPretty
       when CODE_SIGNING_REQUIRED_MATCHER
         formatter.format_error($1)
       when NO_PROFILE_MATCHING_MATCHER
+        formatter.format_error($1)
+      when PROVISIONING_PROFILE_REQUIRED_MATCHER
+        formatter.format_error($1)
+      when NO_CERTIFICATE_MATCHER
         formatter.format_error($1)
       when COMPILE_MATCHER
         formatter.format_compile($2, $1)

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -653,6 +653,10 @@ SAMPLE_NO_PROFILE_MATCHING_ERROR = %Q(
 No profile matching 'TargetName' found:  Xcode couldn't find a profile matching 'TargetName'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.
 )
 
+SAMPLE_SWIFT_UNAVAILABLE = "Swift is unavailable on iOS earlier than 7.0; please set IPHONEOS_DEPLOYMENT_TARGET to 7.0 or later (currently it is '6.0')."
+
+SAMPLE_USE_LEGACY_SWIFT = "“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly."
+
 ################################################################################
 # WARNINGS
 ################################################################################

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -582,6 +582,14 @@ SAMPLE_CODESIGN_ERROR_NO_SPACES = %Q(
 CodeSign error: code signing is required for product type 'Application' in SDK 'iOS 7.0'
 )
 
+SAMPLE_REQUIRES_PROVISION = %Q(
+PROJECT_NAME requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor.
+)
+
+SAMPLE_NO_CERTIFICATE = %Q(
+No certificate matching 'iPhone Distribution: Name (B89SBB0AV9)' for team 'B89SBB0AV9':  Select a different signing certificate for CODE_SIGN_IDENTITY, a team that matches your selected certificate, or switch to automatic provisioning.
+)
+
 SAMPLE_FATAL_COMPILE_ERROR = %Q(
 In file included from /Users/musalj/code/OSS/SampleApp/Pods/SuperCoolPod/SuperAwesomeClass.m:12:
 In file included from /Users/musalj/code/OSS/SampleApp/Pods/../LessCoolPod/LessCoolClass.h:9:

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -473,6 +473,20 @@ module XCPretty
         @parser.parse(SAMPLE_NO_CERTIFICATE)
       end
 
+      it "parses swift unavailable error:" do
+        @formatter.should receive(:format_error).with(
+          SAMPLE_SWIFT_UNAVAILABLE
+        )
+        @parser.parse(SAMPLE_SWIFT_UNAVAILABLE)
+      end
+
+      it "parses use legacy swift error:" do
+        @formatter.should receive(:format_error).with(
+          SAMPLE_USE_LEGACY_SWIFT
+        )
+        @parser.parse(SAMPLE_USE_LEGACY_SWIFT)
+      end
+
       it "parses ld library errors" do
         @formatter.should receive(:format_error).with(
           SAMPLE_LD_LIBRARY_ERROR

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -459,6 +459,20 @@ module XCPretty
         @parser.parse(SAMPLE_NO_PROFILE_MATCHING_ERROR)
       end
 
+      it "parses requires provision error:" do
+        @formatter.should receive(:format_error).with(
+          'PROJECT_NAME requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor.'
+        )
+        @parser.parse(SAMPLE_REQUIRES_PROVISION)
+      end
+
+      it "parses no certificate error:" do
+        @formatter.should receive(:format_error).with(
+          "No certificate matching 'iPhone Distribution: Name (B89SBB0AV9)' for team 'B89SBB0AV9':  Select a different signing certificate for CODE_SIGN_IDENTITY, a team that matches your selected certificate, or switch to automatic provisioning."
+        )
+        @parser.parse(SAMPLE_NO_CERTIFICATE)
+      end
+
       it "parses ld library errors" do
         @formatter.should receive(:format_error).with(
           SAMPLE_LD_LIBRARY_ERROR


### PR DESCRIPTION
Upon a missing Provisioning profile/Code sign identity, the following errors are thrown (using Xcode 8):
missing Provisioning profile:

```
MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor.
Code signing is required for product type 'Application' in SDK 'iOS 10.0'
Code signing is required for product type 'Application' in SDK 'iOS 10.0'
```

missing Code sign identity:

```
No certificate matching 'iPhone Distribution: Name (XXXXXXXXXX)' for team 'XXXXXXXXXX':  Select a different signing certificate for CODE_SIGN_IDENTITY, a team that matches your selected certificate, or switch to automatic provisioning.
Code signing is required for product type 'Application' in SDK 'iOS 10.0'
Code signing is required for product type 'Application' in SDK 'iOS 10.0'
```

From those errors `Code signing is required for product type 'Application' in SDK 'iOS 10.0'` is already captured thanks to https://github.com/supermarin/xcpretty/pull/247. But the other two errors seem to be missing.

I've tried adding unit tests too, ping @supermarin for thoughts on this
