### PR TITLE
fix json-compilation-database pch file path bug

### DIFF
--- a/lib/xcpretty/reporters/json_compilation_database.rb
+++ b/lib/xcpretty/reporters/json_compilation_database.rb
@@ -20,6 +20,10 @@ module XCPretty
       @current_path = nil
     end
 
+    def format_build_target(target, project, configuration)
+      @pch_path = nil
+    end
+
     def format_process_pch_command(file_path)
       @pch_path = file_path
     end


### PR DESCRIPTION
Found  a bug in json_compilation_database.rb about pch file.

When building a target A, which depends on target B. And the Target B has a prefix header and sets the `precompile prefix header` to `YES`. Target A also has its own prefix header, but sets the `precompile prefix header` to `NO`.

First xcodebuild will build target B, set the `@pch_path` in `JSONCompilationDatabase` via `format_process_pch_command`, and everything is fine.

And then it begins to build target A, since the target A sets the `precompile prefix header` to `NO`, the `format_process_pch_command` will not be called, so the `@pch_path` remains the same as target B. That's the problem! the target A's pch path will be replaced by Target B's.

My solution is simply reset the `@pch_path` before every target in `format_build_target`.