### PR TITLE
add optional package attribute to testsuite element

### DIFF
--- a/lib/xcpretty/reporters/junit.rb
+++ b/lib/xcpretty/reporters/junit.rb
@@ -84,6 +84,7 @@ module XCPretty
       set_test_counters
       @last_suite = @document.root.add_element('testsuite')
       @last_suite.attributes['name'] = classname
+      @last_suite.attributes['package'] = classname
       @last_suite
     end
 


### PR DESCRIPTION
For some reason, we need use junit-noframe.xsl to conver to html. That XSLT requires a package attribute on testsuite element. According to JUnit XML reporting file format: http://llg.cubic.org/docs/junit/. This attribute should be derived from name. Though it is optional, I'd suggest adding it to make JUnit report more compatible for more consumers.