### PR TITLE
 COMPILE_WARNING_MATCHER/COMPILE_ERROR_MATCHER failing for relative paths

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -202,7 +202,7 @@ module XCPretty
       # $1 = file_path
       # $2 = file_name
       # $3 = reason
-      COMPILE_WARNING_MATCHER = /^(\/.+\/(.*):.*:.*):\swarning:\s(.*)$/
+      COMPILE_WARNING_MATCHER = /^(.+\/(.*):.*:.*):\swarning:\s(.*)$/
 
       # $1 = ld prefix
       # $2 = warning message
@@ -234,7 +234,7 @@ module XCPretty
       # $1 = file_path
       # $2 = file_name
       # $3 = reason
-      COMPILE_ERROR_MATCHER = /^(\/.+\/(.*):.*:.*):\s(?:fatal\s)?error:\s(.*)$/
+      COMPILE_ERROR_MATCHER = /^(.+\/(.*):.*:.*):\s(?:fatal\s)?error:\s(.*)$/
 
       # @regex Captured groups
       # $1 cursor (with whitespaces and tildes)


### PR DESCRIPTION
COMPILE_WARNING_MATCHER/COMPILE_ERROR_MATCHER no longer require that the file path start with a forward slash