### PR TITLE
Fix compile errors/warnings not displayed

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -201,8 +201,10 @@ module XCPretty
     module Warnings
       # $1 = file_path
       # $2 = file_name
-      # $3 = reason
-      COMPILE_WARNING_MATCHER = /^(\/.+\/(.*):.*:.*):\swarning:\s(.*)$/
+      # $3 = cursor
+      # $4 = line
+      # $5 = reason
+      COMPILE_WARNING_MATCHER = /^(\/.+\/(.*):(.*):(.*)):\swarning:\s(.*)$/
 
       # $1 = ld prefix
       # $2 = warning message
@@ -233,8 +235,10 @@ module XCPretty
       # @regex Captured groups
       # $1 = file_path
       # $2 = file_name
-      # $3 = reason
-      COMPILE_ERROR_MATCHER = /^(\/.+\/(.*):.*:.*):\s(?:fatal\s)?error:\s(.*)$/
+      # $3 = cursor
+      # $4 = line
+      # $5 = reason
+      COMPILE_ERROR_MATCHER = /^(\/.+\/(.*):(.*):(.*)):\s(?:fatal\s)?error:\s(.*)$/
 
       # @regex Captured groups
       # $1 cursor (with whitespaces and tildes)
@@ -438,9 +442,11 @@ module XCPretty
     # @ return Hash { :file_name, :file_path, :reason, :line }
     def update_error_state(text)
       update_error = lambda {
-        current_issue[:reason]    = $3
+        current_issue[:reason]    = $5
         current_issue[:file_path] = $1
         current_issue[:file_name] = $2
+        current_issue[:cursor]    = $3
+        current_issue[:line]      = $4
       }
       if text =~ COMPILE_ERROR_MATCHER
         @formatting_error = true


### PR DESCRIPTION
Whenever a compile error/warning is detected an `update_error` lambda is called. Said lambda sets `reason`, `file_path` and `file_name` of `current_issue`.
However in order for an error to be valid it needs to have `cursor` and `line` according to `error_or_warning_is_present` function.

Modify compiler error/warning regular expressions to capture line and cursor and pass them to `update_error` lambda.

Ping @supermarin for review