### PR TITLE
Add matcher for 'No profile matching 'TargetName' found:' dependency error

### DIFF
--- a/features/simple_format.feature
+++ b/features/simple_format.feature
@@ -226,3 +226,8 @@ Feature: Showing build output in simple format
         Given the target requires code signing
         When I pipe to xcpretty with "--simple --no-color"
         Then I should see the code signing is requried message
+
+    Scenario: Showing no profile matching error
+        Given the matching profile is missing
+        When I pipe to xcpretty with "--simple --no-color"
+        Then I should see the no profile matching message

--- a/features/steps/formatting_steps.rb
+++ b/features/steps/formatting_steps.rb
@@ -144,6 +144,10 @@ Given(/^the target requires code signing$/) do
   add_run_input SAMPLE_CODE_SIGNING_IS_REQUIRED_ERROR
 end
 
+Given(/^the matching profile is missing$/) do
+  add_run_input SAMPLE_NO_PROFILE_MATCHING_ERROR
+end
+
 Then(/^I should see a "(\w+)" completion message$/) do |phase|
   run_output.should start_with("▸ #{phase.capitalize} Succeeded")
 end
@@ -366,5 +370,9 @@ end
 
 Then(/^I should see the code signing is requried message$/) do
   run_output.should include("Code signing is required for product type 'Application' in SDK 'iOS 10.0'")
+end
+
+Then(/^I should see the no profile matching message$/) do
+  run_output.should include("No profile matching 'TargetName' found:  Xcode couldn't find a profile matching 'TargetName'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.")
 end
 

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -231,6 +231,10 @@ module XCPretty
       CODE_SIGNING_REQUIRED_MATCHER = /^(Code signing is required for product type .* in SDK .*)$/
 
       # @regex Captured groups
+      # #1 = whole error
+      NO_PROFILE_MATCHING_MATCHER = /^(No profile matching .* found:.*)$/
+
+      # @regex Captured groups
       # $1 = file_path
       # $2 = file_name
       # $3 = reason
@@ -331,6 +335,8 @@ module XCPretty
       when CODESIGN_ERROR_MATCHER
         formatter.format_error($1)
       when CODE_SIGNING_REQUIRED_MATCHER
+        formatter.format_error($1)
+      when NO_PROFILE_MATCHING_MATCHER
         formatter.format_error($1)
       when COMPILE_MATCHER
         formatter.format_compile($2, $1)

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -641,6 +641,10 @@ SAMPLE_CODE_SIGNING_IS_REQUIRED_ERROR = %Q(
 Code signing is required for product type 'Application' in SDK 'iOS 10.0'
 )
 
+SAMPLE_NO_PROFILE_MATCHING_ERROR = %Q(
+No profile matching 'TargetName' found:  Xcode couldn't find a profile matching 'TargetName'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.
+)
+
 ################################################################################
 # WARNINGS
 ################################################################################

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -452,6 +452,13 @@ module XCPretty
         @parser.parse(SAMPLE_CODESIGN_ERROR_NO_SPACES)
       end
 
+      it "parses No profile matching error:" do
+        @formatter.should receive(:format_error).with(
+          "No profile matching 'TargetName' found:  Xcode couldn't find a profile matching 'TargetName'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor."
+        )
+        @parser.parse(SAMPLE_NO_PROFILE_MATCHING_ERROR)
+      end
+
       it "parses ld library errors" do
         @formatter.should receive(:format_error).with(
           SAMPLE_LD_LIBRARY_ERROR


### PR DESCRIPTION
Example of the error:

```
Check dependencies
No profile matching 'TargetName' found:  Xcode couldn't find a profile matching 'TargetName'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the General tab of the target editor.
Code signing is required for product type 'WatchKit App' in SDK 'iOS 10.2'
```