### PR TITLE
Improve Screenshot Matching

### DIFF
--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -70,7 +70,9 @@ module XCPretty
       Dir.foreach(SCREENSHOT_DIR) do |item|
         next if item == '.' || item == '..' || File.extname(item) != '.png'
 
-        suite_name = find_test_suite(item)
+        suite = item.split(".")[0]
+
+        suite_name = find_test_suite(suite)
         next if suite_name.nil?
 
         @test_suites[suite_name][:screenshots] << item

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -70,9 +70,11 @@ module XCPretty
       Dir.foreach(SCREENSHOT_DIR) do |item|
         next if item == '.' || item == '..' || File.extname(item) != '.png'
 
-        suite = item.split(".")[0]
+        suite = item.split(".")
+        
+        next if suite.empty?
 
-        suite_name = find_test_suite(suite)
+        suite_name = find_test_suite(suite[0])
         next if suite_name.nil?
 
         @test_suites[suite_name][:screenshots] << item

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -70,10 +70,7 @@ module XCPretty
       Dir.foreach(SCREENSHOT_DIR) do |item|
         next if item == '.' || item == '..' || File.extname(item) != '.png'
 
-        suite = item.split(".")
-        next if suite.empty?
-
-        suite_name = find_test_suite(suite[0])
+        suite_name = find_test_suite(item)
         next if suite_name.nil?
 
         @test_suites[suite_name][:screenshots] << item
@@ -82,7 +79,7 @@ module XCPretty
 
     def find_test_suite(image_name)
       @test_suites.each do |key, value|
-        return key if image_name.start_with?(key)
+        return key if image_name.start_with?(key.split('.').last)
       end
       nil
     end

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -71,9 +71,8 @@ module XCPretty
         next if item == '.' || item == '..' || File.extname(item) != '.png'
 
         suite = item.split(".")
-        
         next if suite.empty?
-
+        
         suite_name = find_test_suite(suite[0])
         next if suite_name.nil?
 

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -75,7 +75,7 @@ module XCPretty
         
         suite_name = find_test_suite(suite[0])
         next if suite_name.nil?
-
+        
         @test_suites[suite_name][:screenshots] << item
       end
     end

--- a/lib/xcpretty/reporters/html.rb
+++ b/lib/xcpretty/reporters/html.rb
@@ -72,10 +72,10 @@ module XCPretty
 
         suite = item.split(".")
         next if suite.empty?
-        
+
         suite_name = find_test_suite(suite[0])
         next if suite_name.nil?
-        
+
         @test_suites[suite_name][:screenshots] << item
       end
     end


### PR DESCRIPTION
Improve screenshot matching for Test Suites that include namespaces, such as those written in Swift.

KIF screenshots only contain the name of the file, but xcpretty's test name for Swift tests contains the namespace which fails to match any screenshot.