### PR TITLE
Add support for <module-includes> errors

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -254,6 +254,7 @@ module XCPretty
       # $2 = file path
       FILE_MISSING_ERROR_MATCHER = /^<unknown>:0:\s(error:\s.*)\s'(\/.+\/.*\..*)'$/
 
+      # @regex Captured groups
       # $1 = whole error
       LD_ERROR_MATCHER = /^(ld:.*)/
 
@@ -280,6 +281,10 @@ module XCPretty
       # @regex Captured groups
       # $1 = reference
       SYMBOL_REFERENCED_FROM_MATCHER = /\s+"(.*)", referenced from:$/
+
+      # @regex Captured groups
+      # $1 = error reason
+      MODULE_INCLUDES_ERROR_MATCHER = /^\<module-includes\>:.*?:.*?:\s(?:fatal\s)?(error:\s.*)$/
     end
   end
 
@@ -368,6 +373,8 @@ module XCPretty
         formatter.format_libtool($1)
       when LINKING_MATCHER
         formatter.format_linking($1, $2, $3)
+      when MODULE_INCLUDES_ERROR_MATCHER
+        formatter.format_error($1)
       when TEST_CASE_MEASURED_MATCHER
         formatter.format_measuring_test($1, $2, $3)
       when TEST_CASE_PENDING_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -657,6 +657,8 @@ SAMPLE_SWIFT_UNAVAILABLE = "Swift is unavailable on iOS earlier than 7.0; please
 
 SAMPLE_USE_LEGACY_SWIFT = "“Use Legacy Swift Language Version” (SWIFT_VERSION) is required to be configured correctly for targets which use Swift. Use the [Edit > Convert > To Current Swift Syntax…] menu to choose a Swift version or use the Build Settings editor to configure the build setting directly."
 
+SAMPLE_MODULE_INCLUDES_ERROR = "<module-includes>:1:1: error: umbrella header for module 'ModuleName' does not include header 'Header.h'"
+
 ################################################################################
 # WARNINGS
 ################################################################################

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -523,6 +523,13 @@ module XCPretty
         @formatter.should receive(:format_error)
         @parser.parse(SAMPLE_CODE_SIGNING_IS_REQUIRED_ERROR)
       end
+
+      it "parses module includes error" do
+        @formatter.should receive(:format_error).with(
+          "error: umbrella header for module 'ModuleName' does not include header 'Header.h'"
+        )
+        @parser.parse(SAMPLE_MODULE_INCLUDES_ERROR)
+      end
     end
 
     context "warnings" do


### PR DESCRIPTION
This addresses #282 by adding another matcher for errors formatted like:
`<module-includes>:1:1: error: umbrella header for module 'ModuleName' does not include header 'Header.h'`

Corresponding spec added as well. 

I'm not sure if this should be it's own matcher or if one of the other matchers should be extended to include this case, please let me know if I should update this.