### PR TITLE
Add support to parse parallel iOS simulator output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here's an example workflow for a contribution:
 - These are a full-stack end to end tests
 - You can find features in `features/`. You'll need to write a `feature` and implement it's `steps`.
 - Try to reuse as many matchers as possible
-- This tests are slower because they're executing `xcpretty` command for each test
+- These tests are slower because they're executing `xcpretty` command for each test
 
 Here's an example feature for adding output without UTF8:
 
@@ -61,4 +61,3 @@ end
 #### 3. Implement your awesome contribution
 
 - This should fix unit tests one-by-one, and finally your `feature` will be passing
-

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -17,6 +17,17 @@ SAMPLE_KIWI_SUITE_COMPLETION = "Test Suite 'All tests' finished at 2013-12-08 04
 SAMPLE_OCUNIT_SUITE_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-08 22:09:37 +0000."
 SAMPLE_XCTEST_SUITE_COMPLETION = "Test Suite 'ObjectiveSugarTests.xctest' finished at 2013-12-09 04:42:13 +0000."
 
+SAMPLE_PARALLEL_XCTEST_SUITE_STARTED = "XCTestOutputBarrierTest Suite 'AgaveNectarTests' started at 2017-09-29 15:44:41.825"
+SAMPLE_PARALLEL_XCTEST_RUN_FAILED = "XCTestOutputBarrierTest Suite 'AgaveNectarTests.xctest' failed at 2017-09-29 15:15:18.078."
+SAMPLE_PARALLEL_XCTEST_RUN_BEGINNING = "XCTestOutputBarrierTest Suite 'AgaveNectarTests.xctest' started at 2014-02-28 15:43:42 +0000"
+SAMPLE_PARALLEL_XCTEST = "XCTestOutputBarrierTest Case '-[AgaveNectarTests testDryingIntoPowder]' passed (23.619 seconds)."
+SAMPLE_PARALLEL_XCTEST_CASE_STARTED = "XCTestOutputBarrierTest Case '-[AgaveNectarTests testToffeeProcess]' started."
+SAMPLE_PARALLEL_XCTEST_CASE_WITH_FAILURE = %Q(\
+XCTestOutputBarrierTest Case '-[AgaveNectarTests testRecordListNoSearch]' started.
+XCTestOutputBarrierTest Case '-[AgaveNectarTests testRecordListNoSearch]' failed (21.681 seconds).
+)
+
+SAMPLE_UITEST_CASE_STARTED = "Test Case '-[viewUITests.vmtAboutWindow testConnectToDesktop]' started."
 SAMPLE_UITEST_CASE_WITH_FAILURE = %Q(\
 Test Case '-[viewUITests.vmtAboutWindow testConnectToDesktop]' started.
     t =     0.00s     Start Test at 2016-08-18 09:07:17.822
@@ -672,4 +683,3 @@ SAMPLE_FORMAT_WARNING = %Q(
 )
 
 SAMPLE_WILL_NOT_BE_CODE_SIGNED = "FrameworkName will not be code signed because its settings don't specify a development team."
-

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -168,6 +168,11 @@ module XCPretty
       @parser.parse(SAMPLE_LIBTOOL)
     end
 
+    it "parses parallel xctest start" do
+      @parser.should receive(:update_test_started).with("AgaveNectarTests", "testToffeeProcess")
+      @parser.parse(SAMPLE_PARALLEL_XCTEST_CASE_STARTED)
+    end
+
     it "parses uitest failing tests" do
       @formatter.should receive(:format_failing_test).with(
         "viewUITests.vmtAboutWindow",
@@ -176,6 +181,16 @@ module XCPretty
         "<unknown>:0"
       )
       @parser.parse(SAMPLE_UITEST_CASE_WITH_FAILURE)
+    end
+
+    it "parses parallel uitest failing tests" do
+      @formatter.should receive(:format_failing_test).with(
+        "AgaveNectarTests",
+        "testRecordListNoSearch",
+        "Unable to determine reason for failure",
+        "<unknown>"
+      )
+      @parser.parse(SAMPLE_PARALLEL_XCTEST_CASE_WITH_FAILURE)
     end
 
     it "parses specta failing tests" do
@@ -217,6 +232,13 @@ module XCPretty
       @formatter.should receive(:format_pending_test).with('TAPIConversationSpec',
                                                            'TAPIConversation_createConversation_SendsAPOSTRequestToTheConversationsEndpoint')
       @parser.parse(SAMPLE_PENDING_KIWI_TEST)
+    end
+
+    it "parses passing parallel xctests" do
+      @formatter.should receive(:format_passing_test).with('AgaveNectarTests',
+                                                           'testDryingIntoPowder',
+                                                           '23.619')
+      @parser.parse(SAMPLE_PARALLEL_XCTEST)
     end
 
     it 'parses measuring tests' do
@@ -341,6 +363,11 @@ module XCPretty
       @parser.parse(SAMPLE_SPECTA_TEST_RUN_COMPLETION)
     end
 
+    it "parses parallel XCTest test run failed" do
+      @formatter.should receive(:format_test_run_finished).with('AgaveNectarTests.xctest', '2017-09-29 15:15:18.078.')
+      @parser.parse(SAMPLE_PARALLEL_XCTEST_RUN_FAILED)
+    end
+
     it "parses ocunit test run started" do
       @formatter.should receive(:format_test_run_started).with('ReactiveCocoaTests.octest(Tests)')
       @parser.parse(SAMPLE_OCUNIT_TEST_RUN_BEGINNING)
@@ -351,6 +378,11 @@ module XCPretty
       @parser.parse(SAMPLE_SPECTA_TEST_RUN_BEGINNING)
     end
 
+    it "parses parallel xctest run started" do
+      @formatter.should receive(:format_test_run_started).with('AgaveNectarTests.xctest')
+      @parser.parse(SAMPLE_PARALLEL_XCTEST_RUN_BEGINNING)
+    end
+
     it "parses ocunit test suite started" do
       @formatter.should receive(:format_test_suite_started).with('RACKVOWrapperSpec')
       @parser.parse(SAMPLE_OCUNIT_SUITE_BEGINNING)
@@ -359,6 +391,11 @@ module XCPretty
     it "parses specta test suite started" do
       @formatter.should receive(:format_test_suite_started).with('All tests')
       @parser.parse(SAMPLE_SPECTA_SUITE_BEGINNING)
+    end
+
+    it "parses parallel XCTest test suite started" do
+      @formatter.should receive(:format_test_suite_started).with('AgaveNectarTests')
+      @parser.parse(SAMPLE_PARALLEL_XCTEST_SUITE_STARTED)
     end
 
     context "errors" do
@@ -626,4 +663,3 @@ module XCPretty
 
   end
 end
-


### PR DESCRIPTION
Parses a log file that was created by consolidating log files from multiple simulators run by Xcode 9.