### PR TITLE
Handle ProcessProductPackaging message

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -227,7 +227,7 @@ Style/TrailingBlankLines:
   Enabled: true
   EnforcedStyle: final_blank_line
 
-Style/TrailingComma:
+Style/TrailingCommaInArrayLiteral:
   Enabled: true
 
 Style/TrailingWhitespace:

--- a/lib/xcpretty/formatters/format_methods.rb
+++ b/lib/xcpretty/formatters/format_methods.rb
@@ -44,6 +44,7 @@ module FormatMethods
   def format_phase_success(phase_name)                               end
   def format_preprocess(file)                                        end
   def format_probing_swift_lib(path)                                 end
+  def format_process_entitlements(target)                            end
   def format_process_info_plist(path)                                end
   def format_process_pch(file)                                       end
   def format_process_pch_command(path)                               end

--- a/lib/xcpretty/formatters/simple.rb
+++ b/lib/xcpretty/formatters/simple.rb
@@ -132,6 +132,10 @@ module XCPretty
       format("Probe signature of", path.basename)
     end
 
+    def format_process_entitlements(target)
+      format("Processing entitlements for", target)
+    end
+
     def format_process_info_plist(path)
       format("Process", path.basename)
     end

--- a/lib/xcpretty/parser/chunks.rb
+++ b/lib/xcpretty/parser/chunks.rb
@@ -140,6 +140,16 @@ chunk "Process info.plist" do |c|
   c.line SHELL_BUILTIN
 end
 
+chunk "Process entitlements" do |c|
+  c.line /^ProcessProductPackaging .* (#{PATH})(?:-Simulated)\.xcent$/ do |f, m|
+    f.format_process_entitlements(path(m[1]).basename.to_s)
+  end
+  c.exit /^\s{4}builtin-productPackagingUtility.*$/
+  c.line /.*/
+  c.line SHELL_CD
+  c.line SHELL_EXPORT
+end
+
 chunk "PhaseScriptExecution" do |c|
   c.line /^PhaseScriptExecution\s((\\\ |\S)*)\s/ do |f, m|
     f.format_phase_script_execution(m[1].delete("\\"))

--- a/lib/xcpretty/parser/parser.rb
+++ b/lib/xcpretty/parser/parser.rb
@@ -55,6 +55,11 @@ class Chunk
   # line was recognized, it will either be printed (block given) or ignored (no
   # block given).  If the line was not recognized, it will be printed as it is.
   def handle(line, formatter)
+    if line.match(@exit)
+      Log.debug(@name, "Exiting")
+      return nil
+    end
+
     @line_handlers.each do |handler|
       matches = line.match(handler.first)
       next unless matches
@@ -62,10 +67,6 @@ class Chunk
       Log.debug(@name, "Handling #{line}")
       handler[1].call(formatter, matches) if handler[1]
       return self
-    end
-    if line.match(@exit)
-      Log.debug(@name, "Exiting")
-      return nil
     end
 
     Log.debug(@name, "Not recognized: ", line.chomp)

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -277,6 +277,26 @@ PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock build/Lyft.build/Debug-
 error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
 )
 
+SAMPLE_PROCESS_PRODUCT_PACKAGING = %Q(
+ProcessProductPackaging "" build.noindex/Build/Intermediates.noindex/App.build/QA-iphonesimulator/TargetName.build/TargetName.bundle-Simulated.xcent
+    cd /Users/distiller/src
+    export PATH="/Applications/Xcode-9.3.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin:/Applications/Xcode-9.3.app/Contents/Developer/usr/bin:/Users/distiller/Library/Python/2.7/bin:/Users/distiller/Library/Python/2.7/bin:/Users/distiller/Library/Python/2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+Entitlements:
+
+{
+    "application-identifier" = "TEAMID.com.company.TargetName";
+    "keychain-access-groups" =     (
+        "TEAMID.com.company.TargetName"
+    );
+}
+
+
+    builtin-productPackagingUtility -entitlements -format xml -o /Users/distiller/src/build.noindex/Build/Intermediates.noindex/App.build/QA-iphonesimulator/TargetName.build/TargetName.bundle-Simulated.xcent
+
+)
+
 SAMPLE_NEW_RUN_SCRIPT = %Q(
 PhaseScriptExecution Generate\ View\ Controller\ Factory build/Lyft.build/Debug-iphonesimulator/Lyft.build/Script-679D9DF81B72DA39003A5532.sh
     cd /Users/marinusalj/code/lyft/lyft-temp

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -141,7 +141,7 @@ describe 'Parser' do
         SAMPLE_COPYSTRINGS, SAMPLE_LINK_STORYBOARDS, SAMPLE_PBXCP,
         SAMPLE_CREATE_UNIVERSAL_BINARY, SAMPLE_GENERATE_DSYM, SAMPLE_SYMLINK,
         SAMPLE_SWIFT_CODE_GENERATION, SAMPLE_STRIP, SAMPLE_SET_OWNER_AND_GROUP,
-        SAMPLE_SET_MODE ])
+        SAMPLE_SET_MODE, SAMPLE_PROCESS_PRODUCT_PACKAGING ])
     end
 
     it 'shuts up `cd`' do
@@ -155,13 +155,15 @@ describe 'Parser' do
         SAMPLE_COMPILE_STORYBOARD, SAMPLE_COPYPNGFILE, SAMPLE_COPYSTRINGS,
         SAMPLE_LINK_STORYBOARDS, SAMPLE_PBXCP, SAMPLE_CREATE_UNIVERSAL_BINARY,
         SAMPLE_GENERATE_DSYM, SAMPLE_SYMLINK, SAMPLE_SWIFT_CODE_GENERATION,
-        SAMPLE_STRIP, SAMPLE_SET_OWNER_AND_GROUP, SAMPLE_SET_MODE])
+        SAMPLE_STRIP, SAMPLE_SET_OWNER_AND_GROUP, SAMPLE_SET_MODE,
+        SAMPLE_PROCESS_PRODUCT_PACKAGING])
     end
 
     it 'suppresses builtin-' do
       suppress(/^\s{4}builtin-/, [
         SAMPLE_PROCESS_INFOPLIST, SAMPLE_DITTO, SAMPLE_CPHEADER,
-        SAMPLE_CPRESOURCE, SAMPLE_COPYSTRINGS, SAMPLE_PBXCP])
+        SAMPLE_CPRESOURCE, SAMPLE_COPYSTRINGS, SAMPLE_PBXCP,
+        SAMPLE_PROCESS_PRODUCT_PACKAGING])
     end
 
     it 'shuts up setenv' do
@@ -357,6 +359,14 @@ describe 'Parser' do
     @formatter.flush.should == [
       :format_phase_script_execution,
       "[CP] Check Pods Manifest.lock"
+    ]
+  end
+
+  it 'parses product packaging' do
+    @parser.parse(SAMPLE_PROCESS_PRODUCT_PACKAGING.lines[1])
+    @formatter.flush.should == [
+      :format_process_entitlements,
+      'TargetName.bundle'
     ]
   end
 


### PR DESCRIPTION
This message is printed when reading xcent files. It has an arbitrary
length depending on your entitlements. This currently has one issue
where it prints a newline after itself, because it exits on a specific
string after matching as many lines as possible between the start, and
there's no way to capture output after exiting.