### PR TITLE
Fix universal binary template

### DIFF
--- a/lib/xcpretty/formatters/format_methods.rb
+++ b/lib/xcpretty/formatters/format_methods.rb
@@ -27,7 +27,7 @@ module FormatMethods
   def format_copy_strings_file(path)                                 end
   def format_copy_swift_libs(path)                                   end
   def format_create_product_structure()                              end
-  def format_create_universal_binary()                               end
+  def format_create_universal_binary(path)                           end
   def format_cpresource(source, destination)                         end
   def format_ditto(path)                                             end
   def format_failing_test(suite, test, time, path)                   end


### PR DESCRIPTION
This takes one argument so if formatters don't implement it, xcpretty
crashes