### PR TITLE
Add catch-all formatter

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -49,6 +49,7 @@ module XCPretty
     def format_tiffutil(file);                                 EMPTY; end
     def format_write_file(file);                               EMPTY; end
     def format_write_auxiliary_files;                          EMPTY; end
+    def format_other(text)                                     EMPTY; end
 
     # COMPILER / LINKER ERRORS AND WARNINGS
     def format_compile_error(file_name, file_path, reason,
@@ -150,6 +151,10 @@ module XCPretty
 
     def format_will_not_be_code_signed(message)
       "#{yellow(warning_symbol + " " + message)}"
+    end
+    
+    def format_other(text)
+      ""
     end
 
 

--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -152,7 +152,7 @@ module XCPretty
     def format_will_not_be_code_signed(message)
       "#{yellow(warning_symbol + " " + message)}"
     end
-    
+
     def format_other(text)
       ""
     end

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -423,7 +423,7 @@ module XCPretty
       when WILL_NOT_BE_CODE_SIGNED_MATCHER
         formatter.format_will_not_be_code_signed($1)
       else
-        ""
+        formatter.format_other(text)
       end
     end
 

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -696,4 +696,5 @@ SAMPLE_FORMAT_WARNING = %Q(
 )
 
 SAMPLE_WILL_NOT_BE_CODE_SIGNED = "FrameworkName will not be code signed because its settings don't specify a development team."
+SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING = "This is a string that won't be matched by any other regex."
 

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -361,6 +361,13 @@ module XCPretty
       @parser.parse(SAMPLE_SPECTA_SUITE_BEGINNING)
     end
 
+    it "parses unknown strings" do
+      @formatter.should receive(:format_other).with(
+        SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING
+      )
+      @parser.parse(SAMPLE_FORMAT_OTHER_UNRECOGNIZED_STRING)
+    end
+
     context "errors" do
       it "parses clang errors" do
         @formatter.should receive(:format_error).with(SAMPLE_CLANG_ERROR)


### PR DESCRIPTION
This adds `format_other` to allow you to override behavior in a custom formatter for things that the current parser doesn't know how to match.