### PR TITLE
Fix ProcessProductPackaging for device

### DIFF
--- a/lib/xcpretty/parser/chunks.rb
+++ b/lib/xcpretty/parser/chunks.rb
@@ -141,8 +141,9 @@ chunk "Process info.plist" do |c|
 end
 
 chunk "Process entitlements" do |c|
-  c.line /^ProcessProductPackaging .* (#{PATH})(?:-Simulated)\.xcent$/ do |f, m|
-    f.format_process_entitlements(path(m[1]).basename.to_s)
+  c.line /^ProcessProductPackaging .* (#{PATH})\.xcent$/ do |f, m|
+    product_name = path(m[1]).basename.to_s.sub(/-Simulated$/, "")
+    f.format_process_entitlements(product_name)
   end
   c.exit /^\s{4}builtin-productPackagingUtility.*$/
   c.line /.*/

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -297,6 +297,26 @@ Entitlements:
 
 )
 
+SAMPLE_PROCESS_PRODUCT_PACKAGING_DEVICE = %Q(
+ProcessProductPackaging "" build.noindex/Build/Intermediates.noindex/App.build/QA-iphonesimulator/TargetName.build/TargetName.bundle.xcent
+    cd /Users/distiller/src
+    export PATH="/Applications/Xcode-9.3.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin:/Applications/Xcode-9.3.app/Contents/Developer/usr/bin:/Users/distiller/Library/Python/2.7/bin:/Users/distiller/Library/Python/2.7/bin:/Users/distiller/Library/Python/2.7/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+Entitlements:
+
+{
+    "application-identifier" = "TEAMID.com.company.TargetName";
+    "keychain-access-groups" =     (
+        "TEAMID.com.company.TargetName"
+    );
+}
+
+
+    builtin-productPackagingUtility -entitlements -format xml -o /Users/distiller/src/build.noindex/Build/Intermediates.noindex/App.build/QA-iphonesimulator/TargetName.build/TargetName.bundle.xcent
+
+)
+
 SAMPLE_NEW_RUN_SCRIPT = %Q(
 PhaseScriptExecution Generate\ View\ Controller\ Factory build/Lyft.build/Debug-iphonesimulator/Lyft.build/Script-679D9DF81B72DA39003A5532.sh
     cd /Users/marinusalj/code/lyft/lyft-temp

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -141,7 +141,8 @@ describe 'Parser' do
         SAMPLE_COPYSTRINGS, SAMPLE_LINK_STORYBOARDS, SAMPLE_PBXCP,
         SAMPLE_CREATE_UNIVERSAL_BINARY, SAMPLE_GENERATE_DSYM, SAMPLE_SYMLINK,
         SAMPLE_SWIFT_CODE_GENERATION, SAMPLE_STRIP, SAMPLE_SET_OWNER_AND_GROUP,
-        SAMPLE_SET_MODE, SAMPLE_PROCESS_PRODUCT_PACKAGING ])
+        SAMPLE_SET_MODE, SAMPLE_PROCESS_PRODUCT_PACKAGING,
+        SAMPLE_PROCESS_PRODUCT_PACKAGING_DEVICE])
     end
 
     it 'shuts up `cd`' do
@@ -156,14 +157,16 @@ describe 'Parser' do
         SAMPLE_LINK_STORYBOARDS, SAMPLE_PBXCP, SAMPLE_CREATE_UNIVERSAL_BINARY,
         SAMPLE_GENERATE_DSYM, SAMPLE_SYMLINK, SAMPLE_SWIFT_CODE_GENERATION,
         SAMPLE_STRIP, SAMPLE_SET_OWNER_AND_GROUP, SAMPLE_SET_MODE,
-        SAMPLE_PROCESS_PRODUCT_PACKAGING])
+        SAMPLE_PROCESS_PRODUCT_PACKAGING,
+        SAMPLE_PROCESS_PRODUCT_PACKAGING_DEVICE])
     end
 
     it 'suppresses builtin-' do
       suppress(/^\s{4}builtin-/, [
         SAMPLE_PROCESS_INFOPLIST, SAMPLE_DITTO, SAMPLE_CPHEADER,
         SAMPLE_CPRESOURCE, SAMPLE_COPYSTRINGS, SAMPLE_PBXCP,
-        SAMPLE_PROCESS_PRODUCT_PACKAGING])
+        SAMPLE_PROCESS_PRODUCT_PACKAGING,
+        SAMPLE_PROCESS_PRODUCT_PACKAGING_DEVICE])
     end
 
     it 'shuts up setenv' do
@@ -362,8 +365,16 @@ describe 'Parser' do
     ]
   end
 
-  it 'parses product packaging' do
+  it 'parses product packaging for simulators' do
     @parser.parse(SAMPLE_PROCESS_PRODUCT_PACKAGING.lines[1])
+    @formatter.flush.should == [
+      :format_process_entitlements,
+      'TargetName.bundle'
+    ]
+  end
+
+  it 'parses product packaging for device' do
+    @parser.parse(SAMPLE_PROCESS_PRODUCT_PACKAGING_DEVICE.lines[1])
     @formatter.flush.should == [
       :format_process_entitlements,
       'TargetName.bundle'


### PR DESCRIPTION
Previously this regex required it end with `-Simulated`, that was never
the intention. Just making this non-capturing group optional doesn't
work and PATH ends up capturing the whole thing.