### PR TITLE
Pass the testing debug data through to formatter for future formatting

### DIFF
--- a/lib/xcpretty/formatters/formatter.rb
+++ b/lib/xcpretty/formatters/formatter.rb
@@ -41,6 +41,7 @@ module XCPretty
     def format_preprocess(file);                               EMPTY; end
     def format_pbxcp(file);                                    EMPTY; end
     def format_shell_command(command, arguments);              EMPTY; end
+    def format_test_debug_data(time, message);                 EMPTY; end
     def format_test_run_started(name);                         EMPTY; end
     def format_test_run_finished(name, time);                  EMPTY; end
     def format_test_suite_started(name);                       EMPTY; end

--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -128,6 +128,10 @@ module XCPretty
     # $3 = time
     TEST_CASE_PASSED_MATCHER = /^\s*Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)/
 
+    # @regex Captured groups
+    # $1 = test run time debug data
+    # $2 = test run debug message
+    TEST_CASE_DEBUG_DATA_MATCHER = /^\s+t =\s+(\d+\.\d+s)\s+(.*)$/
 
     # @regex Captured groups
     # $1 = suite
@@ -386,6 +390,8 @@ module XCPretty
         formatter.format_pending_test($1, $2)
       when TEST_CASE_PASSED_MATCHER
         formatter.format_passing_test($1, $2, $3)
+      when TEST_CASE_DEBUG_DATA_MATCHER
+        formatter.format_test_debug_data($1, $2)
       when PODS_ERROR_MATCHER
         formatter.format_error($1)
       when PROCESS_INFO_PLIST_MATCHER

--- a/spec/fixtures/constants.rb
+++ b/spec/fixtures/constants.rb
@@ -17,6 +17,12 @@ SAMPLE_KIWI_SUITE_COMPLETION = "Test Suite 'All tests' finished at 2013-12-08 04
 SAMPLE_OCUNIT_SUITE_COMPLETION = "Test Suite '/Users/musalj/Library/Developer/Xcode/DerivedData/ReactiveCocoa-eznxkbqvgfsnrvetemqloysuwagb/Build/Products/Test/ReactiveCocoaTests.octest(Tests)' finished at 2013-12-08 22:09:37 +0000."
 SAMPLE_XCTEST_SUITE_COMPLETION = "Test Suite 'ObjectiveSugarTests.xctest' finished at 2013-12-09 04:42:13 +0000."
 
+SAMPLE_UITEST_DEBUG_DATA = %Q(\
+Wait for connect to desktop done
+    t =    19.06s     Snapshot accessibility hierarchy for com.vmware.horizon
+    t =    20.31s     Find: Descendants matching type Window
+    t =    20.32s     Find: Elements matching predicate '"rdsh1" IN identifiers'
+)
 SAMPLE_UITEST_CASE_WITH_FAILURE = %Q(\
 Test Case '-[viewUITests.vmtAboutWindow testConnectToDesktop]' started.
     t =     0.00s     Start Test at 2016-08-18 09:07:17.822

--- a/spec/xcpretty/parser_spec.rb
+++ b/spec/xcpretty/parser_spec.rb
@@ -132,6 +132,12 @@ module XCPretty
       @parser.parse(SAMPLE_COPYSTRINGS)
     end
 
+    it "parses UITest debug data" do
+      @formatter.should receive(:format_test_debug_data).with('19.06s', 'Snapshot accessibility hierarchy for com.vmware.horizon')
+      @parser.parse(SAMPLE_UITEST_DEBUG_DATA)
+    end
+
+
     it "parses CpHeader" do
       @formatter.should receive(:format_copy_header_file).with(
         '/path/to/Header.h', '/some other/path/Header.h')


### PR DESCRIPTION
This will allow me to create a more custom formatter to show all debug data while running tests. This is useful for our feature specs that have one VERY large spec, and when it fails, we have no idea where it failed until we go into the build log.

The build log is good, but it's like 6MB, so we have to download it and parse it. Allow us to have a custom formatter will speed up our diagnosis of test failures!