### PR TITLE
Adds support to inhibit warning output through environment variable. closes #175, #237

### DIFF
--- a/lib/xcpretty/parser.rb
+++ b/lib/xcpretty/parser.rb
@@ -419,7 +419,9 @@ module XCPretty
       when SHELL_COMMAND_MATCHER
         formatter.format_shell_command($1, $2)
       when GENERIC_WARNING_MATCHER
-        formatter.format_warning($1)
+        if !ENV["XCPRETTY_INHIBIT_WARNINGS"]
+          formatter.format_warning($1)
+        end        
       when WILL_NOT_BE_CODE_SIGNED_MATCHER
         formatter.format_will_not_be_code_signed($1)
       else
@@ -460,8 +462,10 @@ module XCPretty
         @formatting_error = true
         update_error.call
       elsif text =~ COMPILE_WARNING_MATCHER
-        @formatting_warning = true
-        update_error.call
+        if !ENV["XCPRETTY_INHIBIT_WARNINGS"]
+          @formatting_warning = true
+          update_error.call
+        end
       elsif text =~ CURSOR_MATCHER
         current_issue[:cursor]    = $1.chomp
       elsif @formatting_error || @formatting_warning


### PR DESCRIPTION
Hello! xcpretty is a great tool that we have used for a long time. A few times in the past I wished it could avoid printing warnings on some occasions, especially when running on Travis, which can slow down a lot and break the maximum log size which hinders our ability to understand build failures.
Especially now after we migrated some projects to Swift 4.2 without updating all of its dependencies, the warning output was just unbearable as some builds actually failed because the excessive log made Travis unable to meet some async expectations timeouts.

This PR adds the ability to supress all warning output through the `XCPRETTY_INHIBIT_WARNINGS` environment variable. This was the simplest I was able to understand of Ruby. Also not dependent on third-party adoption (i.e Fastlane doesn't need to include any options to opt-in to this behavior)

Best,
Rafael